### PR TITLE
Corrections in Acquisition card task

### DIFF
--- a/ecpy_hqc_legacy/instruments/drivers/dll/alazar935x.py
+++ b/ecpy_hqc_legacy/instruments/drivers/dll/alazar935x.py
@@ -238,6 +238,7 @@ class Alazar935x(DllInstrument):
                     data[i] += np.sum(rbuf[i*records_per_buffer:
                                            (i+1)*records_per_buffer -
                                            records_to_ignore_val], 0)
+                    data[i] /= records_per_capture
                 else:
                     data[i][start:stop] = rbuf[i*records_per_buffer:
                                                (i+1)*records_per_buffer -
@@ -251,10 +252,6 @@ class Alazar935x(DllInstrument):
         # Abort transfer.
         board.abortAsyncRead()
 
-        if average:
-            for c in range(channel_count):
-                data[c] /= records_per_capture
-
         # Check card is not saturated
         maxADC = 2**16-100
         minADC = 100
@@ -266,16 +263,14 @@ class Alazar935x(DllInstrument):
 
         # XXX convert to volt
 
-        i = 0
         data_f = []
-        for c in channels_tuple:
+        for i, c in enumerate(channels_tuple):
             if c:
                 if average:
-                    data_f.append(np.array([data[i]]))
+                    data_f.append(np.array(data[i]))
                 else:
                     data_f.append(data[i])
-                i += 1
             else:
-                data_f.append(np.zeros(2))
+                data_f.append(np.zeros(1))
 
         return data_f

--- a/ecpy_hqc_legacy/instruments/drivers/dll/sp_adq14.py
+++ b/ecpy_hqc_legacy/instruments/drivers/dll/sp_adq14.py
@@ -203,8 +203,6 @@ class SPADQ14(DllInstrument):
             avg.append(np.zeros(samples_per_record) if c else np.zeros(1))
 
         chs = tuple([i for i, c in enumerate(channels) if c])
-        buffers = buffers
-        avg = avg
         buffers_ptr = (ctypes.c_void_p*2)(*(b.ctypes.data_as(ctypes.c_void_p)
                                             for b in buffers))
 

--- a/ecpy_hqc_legacy/instruments/drivers/dll/sp_adq14.py
+++ b/ecpy_hqc_legacy/instruments/drivers/dll/sp_adq14.py
@@ -196,7 +196,7 @@ class SPADQ14(DllInstrument):
         buffer_size = samples_per_record*records_per_capture
         buffers = []
         avg = []
-        for i, c in enumerate(channels):
+        for c in channels:
             buf = (np.ascontiguousarray(np.empty(buffer_size, dtype=np.int16))
                    if c else np.zeros(1, dtype=np.uint16))
             buffers.append(buf)
@@ -271,9 +271,10 @@ class SPADQ14(DllInstrument):
             for c in chs:
                 avg[c] *= 1.9/65535
         else:
-            buffers = [np.reshape(b.astype(np.float32, copy=False),
+            for i, c in enumerate(channels):
+                if c:
+                    buffers[i] = np.reshape(buffers[i].astype(np.float32),
                                   (-1, samples_per_record)) * 1.9/65535
-                       for b in buffers]
 
         return avg if average else buffers
 

--- a/ecpy_hqc_legacy/instruments/drivers/dll/sp_adq14.py
+++ b/ecpy_hqc_legacy/instruments/drivers/dll/sp_adq14.py
@@ -271,10 +271,9 @@ class SPADQ14(DllInstrument):
             for c in chs:
                 avg[c] *= 1.9/65535
         else:
-            for c in chs:
-                b = buffers[c]
-                b.reshape((-1, samples_per_record))
-                b *= 1.9/65535
+            buffers = [np.reshape(b.astype(np.float32, copy=False),
+                                  (-1, samples_per_record)) * 1.9/65535
+                       for b in buffers]
 
         return avg if average else buffers
 


### PR DESCRIPTION
- Fix in the task perfom method card for the "avg befre demod" operation for the sp card.
- Reduce code duplication.
- Add coherence checks for the "use as ref" option for channel 2.

Missing:
- [x] fix the conversion of traces in the sp card driver when no average is performed (float32 conversion)
- [x] make the alazar driver return 1D array when averaging before demod