### PR TITLE
anapico: fix issue caused by the anapico returning an approximate power

### DIFF
--- a/exopy_hqc_legacy/instruments/drivers/visa/anapico.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/anapico.py
@@ -121,7 +121,7 @@ class Anapico(VisaInstrument):
         """
         self.write('POWER {}'.format(value))
         result = self.ask_for_values('POWER?')[0]
-        if abs(result - value) > 1e-12:
+        if abs(result - value) > 1e-4:
             raise InstrIOError('Instrument did not set correctly the power')
 
     @instrument_property


### PR DESCRIPTION
This is a small patch to fix an issue where the user is not able to set a precise power output on the anapico because it returns an approximate power value (ie 3.0999999 instead of 3.1) which fails the measurement immediately.