### PR TITLE
Fail the measurement when InstrJob timeout

### DIFF
--- a/exopy_hqc_legacy/instruments/drivers/driver_tools.py
+++ b/exopy_hqc_legacy/instruments/drivers/driver_tools.py
@@ -50,6 +50,12 @@ class InstrIOError(InstrError):
     pass
 
 
+class InstrTimeoutError(InstrError):
+    """Generic error raised when an instrument does not behave as expected
+    """
+    pass
+
+
 class instrument_property(property):
     """Property allowing to cache the result of a get operation and return it
     on the next get. The cache can be cleared.
@@ -185,6 +191,10 @@ class InstrJob(object):
         result : bool
             Boolean indicating if the wait succeeded of was interrupted.
 
+        Raises
+        ------
+        InstrTimeoutError:
+            Raised if the operation timeout.
         """
         while True:
             remaining_time = (self.expected_waiting_time -
@@ -205,7 +215,11 @@ class InstrJob(object):
             if self.condition_callable():
                 return True
             if remaining_time < 0 or break_condition_callable():
-                return False
+                if remaining_time < 0:
+                    raise InstrTimeoutError()
+                else:
+                    return False
+
 
     def cancel(self, *args, **kwargs):
         """Cancel the long running job.

--- a/exopy_hqc_legacy/instruments/drivers/driver_tools.py
+++ b/exopy_hqc_legacy/instruments/drivers/driver_tools.py
@@ -221,7 +221,7 @@ class InstrJob(object):
             if remaining_time < 0 or break_condition_callable():
                 if remaining_time < 0:
                     if self.timeout:
-                        self._timeout()
+                        self.timeout()
                     raise InstrTimeoutError()
                 else:
                     return False

--- a/exopy_hqc_legacy/instruments/drivers/driver_tools.py
+++ b/exopy_hqc_legacy/instruments/drivers/driver_tools.py
@@ -163,11 +163,15 @@ class InstrJob(object):
     cancel : Callable, optional
         Function to cancel the task.
 
+    timeout : Callable, optional
+        Function called when the task timeouts
+
     """
-    def __init__(self, condition_callable, expected_waiting_time, cancel):
+    def __init__(self, condition_callable, expected_waiting_time, cancel, timeout):
         self.condition_callable = condition_callable
         self.expected_waiting_time = expected_waiting_time
         self.cancel = cancel
+        self.timeout = timeout
         self._start_time = time.time()
 
     def wait_for_completion(self, break_condition_callable=None, timeout=15,
@@ -194,7 +198,7 @@ class InstrJob(object):
         Raises
         ------
         InstrTimeoutError:
-            Raised if the operation timeout.
+            Raised if the operation timeout. 
         """
         while True:
             remaining_time = (self.expected_waiting_time -
@@ -216,6 +220,8 @@ class InstrJob(object):
                 return True
             if remaining_time < 0 or break_condition_callable():
                 if remaining_time < 0:
+                    if self.timeout:
+                        self._timeout()
                     raise InstrTimeoutError()
                 else:
                     return False

--- a/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_cs4.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_cs4.py
@@ -126,7 +126,7 @@ class CS4(VisaInstrument):
         span = abs(self.read_output_field() - value)
         wait = 60 * span / rate
         job = InstrJob(self.is_target_reached, wait, cancel=self.stop_sweep,
-                       timeout=stop_sweep_safe)
+                       timeout=self.stop_sweep_safe)
         return job
 
     @secure_communication()

--- a/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_cs4.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_cs4.py
@@ -32,7 +32,7 @@ class CS4(VisaInstrument):
     #: Typical fluctuations at the output of the instrument.
     #: We use a class variable since we expect this to be identical for all
     #: instruments.
-    OUTPUT_FLUCTUATIONS = 2e-4
+    OUTPUT_FLUCTUATIONS = 5e-4
 
     caching_permissions = {'heater_state': True,
                            'target_field': True,
@@ -116,6 +116,10 @@ class CS4(VisaInstrument):
 
         # Start ramping.
         self.target_field = value
+        # Added a pause and then sweep up due to a buggy behavior of the source
+        sleep(1)
+        self.activity = 'Hold'
+        sleep(1)
         self.activity = 'To set point'
 
         # Create job.
@@ -124,11 +128,14 @@ class CS4(VisaInstrument):
         job = InstrJob(self.is_target_reached, wait, cancel=self.stop_sweep)
         return job
 
+    @secure_communication()
     def stop_sweep(self):
-        """Stop the field sweep at the current value.
+        """Stop the field sweep at the current value, and turn of the switch heater.
 
         """
         self.activity = 'Hold'
+        driver.heater_state = 'Off'
+        sleep(self.post_switch_wait)
 
     def check_connection(self):
         pass

--- a/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_cs4.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_cs4.py
@@ -125,11 +125,19 @@ class CS4(VisaInstrument):
         # Create job.
         span = abs(self.read_output_field() - value)
         wait = 60 * span / rate
-        job = InstrJob(self.is_target_reached, wait, cancel=self.stop_sweep)
+        job = InstrJob(self.is_target_reached, wait, cancel=self.stop_sweep,
+                       timeout=stop_sweep_safe)
         return job
 
     @secure_communication()
     def stop_sweep(self):
+        """Stop the field sweep at the current value.
+
+        """
+        self.activity = 'Hold'
+
+    @secure_communication()
+    def stop_sweep_safe(self):
         """Stop the field sweep at the current value, and turn of the switch heater.
 
         """

--- a/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_cs4.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_cs4.py
@@ -142,7 +142,7 @@ class CS4(VisaInstrument):
 
         """
         self.activity = 'Hold'
-        driver.heater_state = 'Off'
+        self.heater_state = 'Off'
         sleep(self.post_switch_wait)
 
     def check_connection(self):

--- a/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_g4.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_g4.py
@@ -76,6 +76,16 @@ class C4G(CS4):
         # can't reuse CS4 class because a semi-colon is needed
         self.write('ULIM {};'.format(target * 10))
 
+    @instrument_property
+    @secure_communication()
+    def field_sweep_rate(self):
+        """Rate at which to ramp the field (T/min).
+
+        """
+        # converted from A/s to T/min
+        rate = float(self.ask('RATE? 0'))
+        return rate * (60 * self.field_current_ratio)
+
     @field_sweep_rate.setter
     @secure_communication()
     def field_sweep_rate(self, rate):

--- a/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_g4.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_g4.py
@@ -27,7 +27,8 @@ MAXITER = 10
 
 class C4G(CS4):
     """Driver for the superconducting magnet power supply Cryomagnetics 4G.
-
+    The fields are read and given in kG (can't change it in G4)
+    The display only is in T.
     """
 
     def open_connection(self, **para):
@@ -40,7 +41,7 @@ class C4G(CS4):
             self.read_termination = '\n'
         # Need to write the lower limit in kG for source 4G
         #(LLIM needs to be lower than any ULIM)
-        self.write('LLIM -70')
+        self.write('LLIM -70;')
 
     @secure_communication()
     def read_output_field(self):
@@ -62,7 +63,6 @@ class C4G(CS4):
         """Field that the source will try to reach.
 
         """
-        # in T
         return float(self.ask('ULIM?').strip(' kG')) / 10
 
     @target_field.setter

--- a/exopy_hqc_legacy/manifest.enaml
+++ b/exopy_hqc_legacy/manifest.enaml
@@ -359,7 +359,7 @@ enamldef HqcLegacyManifest(PluginManifest):
                     task = 'meas_mag_field_task:MeasMagFieldTask'
                     view = 'views.meas_mag_field_view:MeasMagFieldView'
                     instruments = ['exopy_hqc_legacy.Legacy.IPS12010',
-                                   'exopy_hqc_legacy.Legacy.CS40',
+                                   'exopy_hqc_legacy.Legacy.CS4',
                                    'exopy_hqc_legacy.Legacy.C4G']
                     metadata = {'loopable': True}
                 Task:

--- a/exopy_hqc_legacy/tasks/tasks/instr/apply_mag_field_task.py
+++ b/exopy_hqc_legacy/tasks/tasks/instr/apply_mag_field_task.py
@@ -65,7 +65,7 @@ class ApplyMagFieldTask(InstrumentTask):
         if driver.heater_state == 'Off':
             job = driver.sweep_to_persistent_field()
             if job.wait_for_completion(self.check_for_interruption,
-                                       timeout=60, refresh_time=3):
+                                       timeout=60, refresh_time=1):
                 driver.heater_state = 'On'
                 sleep(self.post_switch_wait)
             else:
@@ -79,7 +79,7 @@ class ApplyMagFieldTask(InstrumentTask):
             try:
                 normal_end = job.wait_for_completion(self.check_for_interruption,
                                                     timeout=60,
-                                                    refresh_time=10)
+                                                    refresh_time=5)
             except InstrTimeoutError:
                 # job.timeout() has been called, which stops the sweep and turn off 
                 # the switch heater
@@ -101,7 +101,7 @@ class ApplyMagFieldTask(InstrumentTask):
             # sweep down to zero at the fast sweep rate
             job = driver.sweep_to_field(0, driver.fast_sweep_rate)
             job.wait_for_completion(self.check_for_interruption,
-                                    timeout=60, refresh_time=3)
+                                    timeout=60, refresh_time=1)
 
         self.write_in_database('field', target_value)
 

--- a/exopy_hqc_legacy/tasks/tasks/instr/apply_mag_field_task.py
+++ b/exopy_hqc_legacy/tasks/tasks/instr/apply_mag_field_task.py
@@ -81,15 +81,17 @@ class ApplyMagFieldTask(InstrumentTask):
                                                     timeout=60,
                                                     refresh_time=10)
             except InstrTimeoutError:
-                job.cancel() # stops the sweep and turn off the switch heater
+                # job.timeout() has been called, which stops the sweep and turn off 
+                # the switch heater
                 self.write_in_database('field', driver.read_persistent_field())
-                # if not normal_end, fail the measurement
+                # fail the measurement
                 self.root.should_stop.set()
                 raise ValueError(cleandoc('''Field source did not set the field to 
                                           {}'''.format(target_value)))
 
         if not normal_end:
-            # when a stôp signal has been send to the measurement
+            # this happens when a stop signal has been send to the measurement
+            job.cancel()
             return
 
         # turn off heater if required

--- a/exopy_hqc_legacy/tasks/tasks/instr/apply_mag_field_task.py
+++ b/exopy_hqc_legacy/tasks/tasks/instr/apply_mag_field_task.py
@@ -16,6 +16,7 @@ from inspect import cleandoc
 from atom.api import (Unicode, Float, Bool, set_default)
 
 from exopy.tasks.api import InstrumentTask, validators
+from exopy_hqc_legacy.instruments.drivers.driver_tools import InstrTimeoutError
 
 
 class ApplyMagFieldTask(InstrumentTask):
@@ -74,19 +75,22 @@ class ApplyMagFieldTask(InstrumentTask):
             driver.output_fluctuations):
             # set the magnetic field
             job = driver.sweep_to_field(target_value, self.rate)
-            normal_end = job.wait_for_completion(self.check_for_interruption,
-                                                 timeout=60,
-                                                 refresh_time=10)
-            print('field:', driver.read_persistent_field())
 
-        # Always close the switch heater when the ramp was interrupted.
+            try:
+                normal_end = job.wait_for_completion(self.check_for_interruption,
+                                                    timeout=60,
+                                                    refresh_time=10)
+            except InstrTimeoutError:
+                job.cancel() # stops the sweep and turn off the switch heater
+                self.write_in_database('field', driver.read_persistent_field())
+                # if not normal_end, fail the measurement
+                self.root.should_stop.set()
+                raise ValueError(cleandoc('''Field source did not set the field to 
+                                          {}'''.format(target_value)))
+
         if not normal_end:
-            job.cancel() # stops the sweep and turn off the switch heater
-            self.write_in_database('field', driver.read_persistent_field())
-            # if not normal_end, fail the measurement
-            self.root.should_stop.set()
-            raise ValueError(cleandoc('''Field source did not set the field to 
-                                         {}'''.format(target_value)))
+            # when a stôp signal has been send to the measurement
+            return
 
         # turn off heater if required
         if self.auto_stop_heater:

--- a/tests/tasks/tasks/instr/instr_helper.py
+++ b/tests/tasks/tasks/instr/instr_helper.py
@@ -25,7 +25,8 @@ class DummyJob(InstrJob):
 
     """
     def __init__(self):
-        super(DummyJob, self).__init__(lambda: True, 0.1, lambda: None)
+        super(DummyJob, self).__init__(lambda: True, 0.1, lambda: None, 
+                                       lambda: None)
 
 
 class HelperMeta(type):

--- a/tests/tasks/tasks/instr/test_apply_mag_field_task.py
+++ b/tests/tasks/tasks/instr/test_apply_mag_field_task.py
@@ -43,11 +43,10 @@ class TestApplyMagFieldTask(object):
             {'Test1':
                 {'connections': {'C': {'owner': [],
                                        'output_fluctuations': 1e-6,
-                                       'heater_state': []}},
+                                       'heater_state': ['On', 'Off']}},
                  'settings': {'S': {'sweep_to_field': [DummyJob(),  DummyJob(),
                                                        DummyJob()],
                                     'sweep_to_persistent_field': [DummyJob()],
-                                    'heater_state': ['On', 'Off'],
                                     'read_persistent_field': [1],
                                     'check_connection': [True]}}
                  }

--- a/tests/tasks/tasks/instr/test_apply_mag_field_task.py
+++ b/tests/tasks/tasks/instr/test_apply_mag_field_task.py
@@ -43,7 +43,9 @@ class TestApplyMagFieldTask(object):
             {'Test1':
                 {'connections': {'C': {'owner': [],
                                        'output_fluctuations': 1e-6,
-                                       'heater_state': ['On', 'Off']}},
+                                       'heater_state': ['On', 'Off'],
+                                       'fast_sweep_rate': '1.',
+                                       'field_sweep_rate': '1.'}},
                  'settings': {'S': {'sweep_to_field': [DummyJob(),  DummyJob(),
                                                        DummyJob()],
                                     'sweep_to_persistent_field': [DummyJob()],
@@ -85,8 +87,6 @@ class TestApplyMagFieldTask(object):
 
         """
         self.task.field = '2.0'
-        self.task.fast_sweep_rate = '1.0'
-        self.task.field_sweep_rate = '1.0'
 
         self.root.prepare()
         self.task.perform()

--- a/tests/tasks/tasks/instr/test_apply_mag_field_task.py
+++ b/tests/tasks/tasks/instr/test_apply_mag_field_task.py
@@ -85,6 +85,8 @@ class TestApplyMagFieldTask(object):
 
         """
         self.task.field = '2.0'
+        self.task.fast_sweep_rate = '1.0'
+        self.task.field_sweep_rate = '1.0'
 
         self.root.prepare()
         self.task.perform()

--- a/tests/tasks/tasks/instr/test_apply_mag_field_task.py
+++ b/tests/tasks/tasks/instr/test_apply_mag_field_task.py
@@ -37,7 +37,7 @@ class TestApplyMagFieldTask(object):
                                       parallel={'activated': False})
         self.root.add_child_task(0, self.task)
 
-        self.root.run_time[DRIVERS] = {'Test': (InstrHelper({'heater_state': ['On', 'Off']}),
+        self.root.run_time[DRIVERS] = {'Test': (InstrHelper(),
                                                 InstrHelperStarter())}
         self.root.run_time[PROFILES] =\
             {'Test1':
@@ -47,6 +47,7 @@ class TestApplyMagFieldTask(object):
                  'settings': {'S': {'sweep_to_field': [DummyJob(),  DummyJob(),
                                                        DummyJob()],
                                     'sweep_to_persistent_field': [DummyJob()],
+                                    'heater_state': ['On', 'Off'],
                                     'read_persistent_field': [1],
                                     'check_connection': [True]}}
                  }

--- a/tests/tasks/tasks/instr/test_apply_mag_field_task.py
+++ b/tests/tasks/tasks/instr/test_apply_mag_field_task.py
@@ -37,7 +37,7 @@ class TestApplyMagFieldTask(object):
                                       parallel={'activated': False})
         self.root.add_child_task(0, self.task)
 
-        self.root.run_time[DRIVERS] = {'Test': (InstrHelper(),
+        self.root.run_time[DRIVERS] = {'Test': (InstrHelper,
                                                 InstrHelperStarter())}
         self.root.run_time[PROFILES] =\
             {'Test1':

--- a/tests/tasks/tasks/instr/test_apply_mag_field_task.py
+++ b/tests/tasks/tasks/instr/test_apply_mag_field_task.py
@@ -37,7 +37,7 @@ class TestApplyMagFieldTask(object):
                                       parallel={'activated': False})
         self.root.add_child_task(0, self.task)
 
-        self.root.run_time[DRIVERS] = {'Test': (InstrHelper,
+        self.root.run_time[DRIVERS] = {'Test': (InstrHelper({'heater_state': ['On', 'Off']}),
                                                 InstrHelperStarter())}
         self.root.run_time[PROFILES] =\
             {'Test1':


### PR DESCRIPTION
I did not stop the measurement stopping in the InstrJob for two reasons;
- for now InstrJob does not have access to the root task
- one could want to take specific action when the InstrJob timeouts; these could be added in the cancel() method of the InstrJob but cancel() is also called when the measurement is stopped and one could want different behaviors (besides, again cancel does not have access to the root task)

In the end it seemed more logical to me to stop the measurement in the Task when the job fails rather than in the Job itself, but feel free to change if you want.