### PR TITLE
Remove all uses of ask_for_values

### DIFF
--- a/exopy_hqc_legacy/instruments/drivers/visa/agilent_multimeters.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/agilent_multimeters.py
@@ -58,10 +58,9 @@ class Agilent34410A(VisaInstrument):
         """Return the DC voltage measured by the instrument
         """
         instruction = "MEASure:VOLTage:DC? {},{}"
-        value = self.ask_for_values(instruction.format(mes_range,
-                                                       mes_resolution))
+        value = self.query(instruction.format(mes_range, mes_resolution))
         if value:
-            return value[0]
+            return float(value)
         else:
             raise InstrIOError('DC voltage measure failed')
 
@@ -70,10 +69,9 @@ class Agilent34410A(VisaInstrument):
         """Return the AC voltage measured by the instrument
         """
         instruction = "MEASure:VOLTage:AC? {},{}"
-        value = self.ask_for_values(instruction.format(mes_range,
-                                                       mes_resolution))
+        value = self.query(instruction.format(mes_range, mes_resolution))
         if value:
-            return value[0]
+            return float(value)
         else:
             raise InstrIOError('AC voltage measure failed')
 
@@ -82,10 +80,10 @@ class Agilent34410A(VisaInstrument):
         """Return the resistance measured by the instrument
         """
         instruction = "MEASure:RESistance? {},{}"
-        value = self.ask_for_values(instruction.format(mes_range,
+        value = self.query(instruction.format(mes_range,
                                                        mes_resolution))
         if value:
-            return value[0]
+            return float(value)
         else:
             raise InstrIOError('Resistance measure failed')
 
@@ -94,10 +92,9 @@ class Agilent34410A(VisaInstrument):
         """Return the DC current measured by the instrument
         """
         instruction = "MEASure:CURRent:DC? {},{}"
-        value = self.ask_for_values(instruction.format(mes_range,
-                                                       mes_resolution))
+        value = self.query(instruction.format(mes_range, mes_resolution))
         if value:
-            return value[0]
+            return float(value)
         else:
             raise InstrIOError('DC current measure failed')
 
@@ -106,9 +103,8 @@ class Agilent34410A(VisaInstrument):
         """Return the AC current measured by the instrument
         """
         instruction = "MEASure:CURRent:AC? {},{}"
-        value = self.ask_for_values(instruction.format(mes_range,
-                                                       mes_resolution))
+        value = self.query(instruction.format(mes_range,  mes_resolution))
         if value:
-            return value[0]
+            return float(value)
         else:
             raise InstrIOError('AC current measure failed')

--- a/exopy_hqc_legacy/instruments/drivers/visa/agilent_pna.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/agilent_pna.py
@@ -13,13 +13,6 @@ import logging
 from inspect import cleandoc
 import numpy as np
 
-try:
-    from visa import ascii, single, double
-except ImportError:
-    ascii = 2
-    single = 1
-    double = 3
-
 from visa import VisaIOError, constants
 
 from ..driver_tools import (BaseInstrument, InstrIOError, InstrError,
@@ -90,13 +83,13 @@ class AgilentPNAChannel(BaseInstrument):
 
         data_request = 'CALCulate{}:DATA? FDATA'.format(self._channel)
         if self._pna.data_format == 'REAL,32':
-            data = self._pna.ask_for_values(data_request, single)
+            data = self._pna.query_binary_values(data_request, 'f')
 
         elif self._pna.data_format == 'REAL,64':
-            data = self._pna.ask_for_values(data_request, double)
+            data = self._pna.query_binary_values(data_request, 'd')
 
         else:
-            data = self._pna.ask_for_values(data_request, ascii)
+            data = self._pna.query_ascii_values(data_request, ascii)
 
         if data:
             return np.array(data)
@@ -127,13 +120,13 @@ class AgilentPNAChannel(BaseInstrument):
 
         data_request = 'CALCulate{}:DATA? SDATA'.format(self._channel)
         if self._pna.data_format == 'REAL,32':
-            data = self._pna.ask_for_values(data_request, single)
+            data = self._pna.query_binary_values(data_request, 'f')
 
         elif self._pna.data_format == 'REAL,64':
-            data = self._pna.ask_for_values(data_request, double)
+            data = self._pna.query_binary_values(data_request, 'd')
 
         else:
-            data = self._pna.ask_for_values(data_request, ascii)
+            data = self._pna.query_ascii_values(data_request)
 
         if not meas_name:
             meas_name = self.selected_measure
@@ -175,7 +168,7 @@ class AgilentPNAChannel(BaseInstrument):
 
             while True:
                 try:
-                    done = self._pna.ask_for_values('*OPC?')[0]
+                    done = int(self._pna.query('*OPC?'))
                     break
                 except VisaIOError as e:
                     # Getting an timeout here simply means that the
@@ -193,7 +186,7 @@ class AgilentPNAChannel(BaseInstrument):
         """
         """
         request = 'CALCulate{}:PARameter:CATalog:EXTended?'
-        meas = self._pna.ask(request.format(self._channel))
+        meas = self._pna.query(request.format(self._channel))
 
         if meas:
             if 'NO CATALOG' in meas:
@@ -212,7 +205,7 @@ class AgilentPNAChannel(BaseInstrument):
         """
         """
         catalog_request = 'CALCulate{}:PARameter:CATalog:EXTended?'
-        measures = self._pna.ask(catalog_request.format(self._channel))
+        measures = self._pna.query(catalog_request.format(self._channel))
 
         if meas_name not in measures:
             param = meas_name.split(':')[1]
@@ -222,7 +215,7 @@ class AgilentPNAChannel(BaseInstrument):
                                                meas_name,
                                                param))
 
-            meas = self._pna.ask(catalog_request.format(self._channel))
+            meas = self._pna.query(catalog_request.format(self._channel))
             if meas:
                 if meas_name not in meas:
                     mess = cleandoc('''The Pna did not create the
@@ -237,7 +230,7 @@ class AgilentPNAChannel(BaseInstrument):
         self._pna.write(
             "CALCulate{}:PARameter:DELete '{}'".format(self._channel,
                                                        meas_name))
-        meas = self._pna.ask('CALCulate{}:PARameter:CATalog:EXTended?'.format(
+        meas = self._pna.query('CALCulate{}:PARameter:CATalog:EXTended?'.format(
                              self._channel))
         if meas:
             if meas_name in meas:
@@ -267,7 +260,7 @@ class AgilentPNAChannel(BaseInstrument):
 
         self._pna.write('CALCulate{}:FORMat {}'.format(self._channel,
                                                        meas_format))
-        res = self._pna.ask('CALCulate{}:FORMat?'.format(self._channel))
+        res = self._pna.query('CALCulate{}:FORMat?'.format(self._channel))
         if meas_name and selected_meas:
             self.selected_measure = selected_meas
         else:
@@ -287,7 +280,7 @@ class AgilentPNAChannel(BaseInstrument):
         self._pna.write("DISPlay:WINDow{}:TRACe{}:FEED '{}'".format(window_num,
                         trace_num, meas_name))
 
-        traces = self._pna.ask('DISPlay:WINDow{}:CATalog?'.format(window_num))
+        traces = self._pna.query('DISPlay:WINDow{}:CATalog?'.format(window_num))
         if str(trace_num) not in traces:
             raise InstrIOError(cleandoc('''The Pna did not bind the meas {}
                 to window {}'''.format(meas_name, window_num)))
@@ -335,10 +328,9 @@ class AgilentPNAChannel(BaseInstrument):
     def frequency(self):
         """Frequency getter method
         """
-        freq = self._pna.ask_for_values('SENS{}:FREQuency:CENTer?'.format(
-                                        self._channel))
+        freq = self._pna.query('SENS{}:FREQuency:CENTer?'.format(self._channel))
         if freq:
-            return freq[0]
+            return float(freq)
         else:
             raise InstrIOError(cleandoc('''Agilent PNA did not return the
                     channel {} frequency'''.format(self._channel)))
@@ -350,10 +342,9 @@ class AgilentPNAChannel(BaseInstrument):
         """
         self._pna.write('SENS{}:FREQuency:CENTer {}'.format(self._channel,
                                                             value))
-        result = self._pna.ask_for_values('SENS{}:FREQuency:CENTer?'.format(
-                                          self._channel))
+        result = self._pna.query('SENS{}:FREQuency:CENTer?'.format(self._channel))
         if result:
-            if abs(result[0] - value)/value > 10**-12:
+            if abs(float(result) - value)/value > 10**-12:
                 raise InstrIOError(cleandoc('''PNA did not set correctly the
                     channel {} frequency'''.format(self._channel)))
         else:
@@ -368,10 +359,9 @@ class AgilentPNAChannel(BaseInstrument):
         WARNING: this command will not work if the trace selection has not been
         made by the software beforehand
         """
-        trace_nb = self._pna.ask_for_values('CALC{}:PAR:MNUM?'.format(
-            self._channel))
+        trace_nb = self._pna.query('CALC{}:PAR:MNUM?'.format(self._channel))
         if trace_nb:
-            return trace_nb[0]
+            return int(trace_nb)
         else:
             raise InstrIOError(cleandoc('''Agilent PNA did not return the
                     trace number on channel {} '''.format(self._channel)))
@@ -382,10 +372,9 @@ class AgilentPNAChannel(BaseInstrument):
         """Current trace number setter method
         """
         self._pna.write('CALC{}:PAR:MNUM {}'.format(self._channel, value))
-        result = self._pna.ask_for_values('CALC{}:PAR:MNUM?'.format(
-                                          self._channel))
+        result = self._pna.query('CALC{}:PAR:MNUM?'.format(self._channel))
         if result:
-            if abs(result[0] - value)/value > 10**-12:
+            if abs(float(result) - value)/value > 10**-12:
                 msg = 'PNA could not set the trace number {} on channel {}'
                 raise InstrIOError(msg.format(value, self._channel))
         else:
@@ -401,22 +390,22 @@ class AgilentPNAChannel(BaseInstrument):
         sweep_type = self.sweep_type
         sweep_points = self.sweep_points
         if sweep_type == 'LIN':
-            sweep_start = self._pna.ask_for_values(
-                'SENSe{}:FREQuency:STARt?'.format(self._channel))[0]*1e-9
-            sweep_stop = self._pna.ask_for_values(
-                'SENSe{}:FREQuency:STOP?'.format(self._channel))[0]*1e-9
+            sweep_start = float(self._pna.query(
+                'SENSe{}:FREQuency:STARt?'.format(self._channel)))*1e-9
+            sweep_stop = float(self._pna.query(
+                'SENSe{}:FREQuency:STOP?'.format(self._channel)))*1e-9
             return np.linspace(sweep_start, sweep_stop, sweep_points)
         elif sweep_type == 'POW':
-            sweep_start = self._pna.ask_for_values('SOURce{}:POWer:STARt?'
-                                                   .format(self._channel))[0]
-            sweep_stop = self._pna.ask_for_values('SOURce{}:POWer:STOP?'
-                                                  .format(self._channel))[0]
+            sweep_start = float(self._pna.query('SOURce{}:POWer:STARt?'
+                                                .format(self._channel)))
+            sweep_stop = float(self._pna.query('SOURce{}:POWer:STOP?'
+                                               .format(self._channel)))
             return np.linspace(sweep_start, sweep_stop, sweep_points)
         elif sweep_type == 'LOG':
-            sweep_start = self._pna.ask_for_values('SENSe{}:FREQuency:STARt?'
-                                                   .format(self._channel))[0]
-            sweep_stop = self._pna.ask_for_values('SENSe{}:FREQuency:STOP?'
-                                                  .format(self._channel))[0]
+            sweep_start = float(self._pna.query('SENSe{}:FREQuency:STARt?'
+                                                .format(self._channel)))
+            sweep_stop = float(self._pna.query('SENSe{}:FREQuency:STOP?'
+                                               .format(self._channel)))
             return np.logspace(sweep_start*1e-9, sweep_stop*1e-9, sweep_points)
         else:
             raise InstrIOError(cleandoc('''Sweep type of PNA not yet
@@ -427,11 +416,10 @@ class AgilentPNAChannel(BaseInstrument):
     def power(self):
         """Power getter method
         """
-        power = self._pna.ask_for_values('SOUR{}:POWer{}:AMPL?'.format(
-                                         self._channel,
-                                         self.port))
+        power = self._pna.query('SOUR{}:POWer{}:AMPL?'.format(self._channel,
+                                                              self.port))
         if power:
-            return power[0]
+            return float(power)
         else:
             raise InstrIOError(cleandoc('''Agilent PNA did not return the
                     channel {} power for port {}'''.format(self._channel,
@@ -445,11 +433,10 @@ class AgilentPNAChannel(BaseInstrument):
         self._pna.write('SOUR{}:POWer{}:AMPL {}'.format(self._channel,
                                                         self.port,
                                                         value))
-        result = self._pna.ask_for_values('SOUR{}:POWer{}:AMPL?'.format(
-                                          self._channel,
-                                          self.port))
+        result = self._pna.query('SOUR{}:POWer{}:AMPL?'.format(self._channel,
+                                                               self.port))
         if result:
-            if abs(result[0] > value) > 10**-12:
+            if abs(float(result) > value) > 10**-12:
                 raise InstrIOError(cleandoc('''PNA did not set correctly the
                     channel {} power for port {}'''.format(self._channel,
                                                            self.port)))
@@ -466,7 +453,7 @@ class AgilentPNAChannel(BaseInstrument):
         WARNING: this command will not work if the trace selection has not been
         made by the software beforehand
         """
-        meas = self._pna.ask('CALC{}:PARameter:SELect?'.format(self._channel))
+        meas = self._pna.query('CALC{}:PARameter:SELect?'.format(self._channel))
         if meas:
             return meas[1:-1]
         else:
@@ -481,7 +468,7 @@ class AgilentPNAChannel(BaseInstrument):
         self._pna.write("CALC{}:PARameter:SELect '{}'".format(self._channel,
                                                               value))
         mess = 'CALC{}:PARameter:SELect?'.format(self._channel)
-        result = self._pna.ask(mess)
+        result = self._pna.query(mess)
         if result:
             if result[1:-1] != value:
                 raise InstrIOError(cleandoc('''PNA did not set correctly the
@@ -492,8 +479,7 @@ class AgilentPNAChannel(BaseInstrument):
     def if_bandwidth(self):
         """
         """
-        if_bw = self._pna.ask_for_values('SENSe{}:BANDwidth?'.format(
-                                         self._channel))
+        if_bw = self._pna.query('SENSe{}:BANDwidth?'.format(self._channel))
         if if_bw:
             return if_bw[0]
         else:
@@ -506,10 +492,9 @@ class AgilentPNAChannel(BaseInstrument):
         """
         """
         self._pna.write('SENSe{}:BANDwidth {}'.format(self._channel, value))
-        result = self._pna.ask_for_values('SENSe{}:BANDwidth?'.format(
-                                          self._channel))
+        result = self._pna.query('SENSe{}:BANDwidth?'.format(self._channel))
         if result:
-            if abs(result[0] > value) > 10**-12:
+            if abs(float(result) > value) > 10**-12:
                 raise InstrIOError(cleandoc('''PNA did not set correctly the
                     channel {} IF bandwidth'''.format(self._channel)))
         else:
@@ -521,7 +506,7 @@ class AgilentPNAChannel(BaseInstrument):
     def sweep_mode(self):
         """
         """
-        mode = self._pna.ask('SENSe{}:SWEep:MODE?'.format(self._channel))
+        mode = self._pna.query('SENSe{}:SWEep:MODE?'.format(self._channel))
         if mode:
             return mode
         else:
@@ -534,7 +519,7 @@ class AgilentPNAChannel(BaseInstrument):
         """
         """
         self._pna.write('SENSe{}:SWEep:MODE {}'.format(self._channel, value))
-        result = self._pna.ask('SENSe{}:SWEep:MODE?'.format(self._channel))
+        result = self._pna.query('SENSe{}:SWEep:MODE?'.format(self._channel))
 
         if result.lower() != value.lower()[:len(result)]:
             raise InstrIOError(cleandoc('''PNA did not set correctly the
@@ -545,7 +530,7 @@ class AgilentPNAChannel(BaseInstrument):
     def sweep_type(self):
         """
         """
-        sweep_type = self._pna.ask('SENSe{}:SWEep:Type?'.format(self._channel))
+        sweep_type = self._pna.query('SENSe{}:SWEep:Type?'.format(self._channel))
         if sweep_type:
             return sweep_type
         else:
@@ -558,7 +543,7 @@ class AgilentPNAChannel(BaseInstrument):
         """
         """
         self._pna.write('SENSe{}:SWEep:TYPE {}'.format(self._channel, value))
-        result = self._pna.ask('SENSe{}:SWEep:TYPE?'.format(self._channel))
+        result = self._pna.query('SENSe{}:SWEep:TYPE?'.format(self._channel))
 
         if result.lower() != value.lower()[:len(result)]:
             raise InstrIOError(cleandoc('''PNA did not set correctly the
@@ -569,10 +554,10 @@ class AgilentPNAChannel(BaseInstrument):
     def sweep_points(self):
         """
         """
-        points = self._pna.ask_for_values('SENSe{}:SWEep:POINts?'.format(
+        points = self._pna.query('SENSe{}:SWEep:POINts?'.format(
                                           self._channel))
         if points:
-            return int(points[0])
+            return int(points)
         else:
             raise InstrIOError(cleandoc('''Agilent PNA did not return the
                     channel {} sweep point number'''.format(self._channel)))
@@ -583,10 +568,10 @@ class AgilentPNAChannel(BaseInstrument):
         """
         """
         self._pna.write('SENSe{}:SWEep:POINts {}'.format(self._channel, value))
-        result = self._pna.ask_for_values('SENSe{}:SWEep:POINts?'.format(
+        result = self._pna.query('SENSe{}:SWEep:POINts?'.format(
                                           self._channel))
         if result:
-            if result[0] != value:
+            if int(result) != value:
                 raise InstrIOError(cleandoc('''PNA did not set correctly the
                     channel {} sweep point number'''.format(self._channel)))
         else:
@@ -598,10 +583,9 @@ class AgilentPNAChannel(BaseInstrument):
     def sweep_time(self):
         """Sweep time in seconds
         """
-        time = self._pna.ask_for_values('sense{}:sweep:time?'.format(
-            self._channel))
+        time = self._pna.query('sense{}:sweep:time?'.format(self._channel))
         if time:
-            return time[0]
+            return float(time)
         else:
             raise InstrIOError(cleandoc('''Agilent PNA did not return the
                     channel {} sweep point number'''.format(self._channel)))
@@ -618,9 +602,9 @@ class AgilentPNAChannel(BaseInstrument):
     def average_state(self):
         """
         """
-        state = self._pna.ask('SENSe{}:AVERage:STATe?'.format(self._channel))
+        state = self._pna.query('SENSe{}:AVERage:STATe?'.format(self._channel))
         if state:
-            return bool(state)
+            return bool(int(state))
         else:
             raise InstrIOError(cleandoc('''Agilent PNA did not return the
                     channel {} average state'''.format(self._channel)))
@@ -632,9 +616,9 @@ class AgilentPNAChannel(BaseInstrument):
         """
         self._pna.write('SENSe{}:AVERage:STATe {}'.format(self._channel,
                         value))
-        result = self._pna.ask('SENSe{}:AVERage:STATe?'.format(self._channel))
+        result = self._pna.query('SENSe{}:AVERage:STATe?'.format(self._channel))
 
-        if bool(result) != value:
+        if bool(int(result)) != value:
             raise InstrIOError(cleandoc('''PNA did not set correctly the
                 channel {} average state'''.format(self._channel)))
 
@@ -643,10 +627,9 @@ class AgilentPNAChannel(BaseInstrument):
     def average_count(self):
         """
         """
-        count = self._pna.ask_for_values('SENSe{}:AVERage:COUNt?'.format(
-                                         self._channel))
+        count = self._pna.query('SENSe{}:AVERage:COUNt?'.format(self._channel))
         if count:
-            return count[0]
+            return int(count)
         else:
             raise InstrIOError(cleandoc('''Agilent PNA did not return the
                     channel {} average count'''.format(self._channel)))
@@ -661,10 +644,9 @@ class AgilentPNAChannel(BaseInstrument):
                         value))
         self._pna.write('SENSe{}:SWE:GRO:COUNt {}'.format(self._channel,
                         value))
-        result = self._pna.ask_for_values('SENSe{}:AVERage:COUNt?'.format(
-                                          self._channel))
+        result = self._pna.query('SENSe{}:AVERage:COUNt?'.format( self._channel))
         if result:
-            if result[0] == value:
+            if int(result) == value:
                 raise InstrIOError(cleandoc('''PNA did not set correctly the
                     channel {} average count'''.format(self._channel)))
         else:
@@ -676,7 +658,7 @@ class AgilentPNAChannel(BaseInstrument):
     def average_mode(self):
         """
         """
-        mode = self._pna.ask('SENSe{}:AVERage:MODE?'.format(self._channel))
+        mode = self._pna.query('SENSe{}:AVERage:MODE?'.format(self._channel))
         if mode:
             return mode
         else:
@@ -689,7 +671,7 @@ class AgilentPNAChannel(BaseInstrument):
         """
         """
         self._pna.write('SENSe{}:AVERage:MODE {}'.format(self._channel, value))
-        result = self._pna.ask('SENSe{}:AVERage:MODE?'.format(self._channel))
+        result = self._pna.query('SENSe{}:AVERage:MODE?'.format(self._channel))
 
         if result.lower() != value.lower()[:len(result)]:
             raise InstrIOError(cleandoc('''PNA did not set correctly the
@@ -700,10 +682,9 @@ class AgilentPNAChannel(BaseInstrument):
     def electrical_delay(self):
         """electrical delay for the selected trace in ns
         """
-        mode = self._pna.ask_for_values('CALC{}:CORR:EDEL:TIME?'.format(
-                                                    self._channel))
+        mode = self._pna.query('CALC{}:CORR:EDEL:TIME?'.format(self._channel))
         if mode:
-            return mode[0]*1000000000.0
+            return float(mode)*1000000000.0
         else:
             raise InstrIOError(cleandoc('''Agilent PNA did not return the
                     channel {} electrical delay'''.format(self._channel)))
@@ -758,14 +739,14 @@ class AgilentPNA(VisaInstrument):
     def clear_traces_from_window(self, window_num):
         """
         """
-        traces = self.ask('DISPlay:WINDow{}:CATalog?'.format(window_num))
+        traces = self.query('DISPlay:WINDow{}:CATalog?'.format(window_num))
         if 'EMPTY' not in traces:
             for trace in traces[1:-1].split(','):
                 mess = 'DISPlay:WINDow{}:TRACe{}:DELete'.format(window_num,
                                                                 int(trace))
                 self.write(mess)
 
-            traces = self.ask('DISPlay:WINDow{}:CATalog?'.format(window_num))
+            traces = self.query('DISPlay:WINDow{}:CATalog?'.format(window_num))
             if 'EMPTY' not in traces:
                 raise InstrIOError(cleandoc('''Agilent PNA did not clear all
                     traces from window {}'''.format(window_num)))
@@ -784,7 +765,7 @@ class AgilentPNA(VisaInstrument):
     def check_operation_completion(self):
         """
         """
-        bites = self.ask('*ESR?')
+        bites = self.query('*ESR?')
         status_byte = ('{0:08b}'.format(int(bites)))[::-1]
         return bool(int(status_byte[0]))
 
@@ -796,7 +777,7 @@ class AgilentPNA(VisaInstrument):
             self.write('SENSe{}:SWEep:MODE HOLD'.format(channel))
 
         for channel in self.defined_channels:
-            result = self.ask('SENSe{}:SWEep:MODE?'.format(channel))
+            result = self.query('SENSe{}:SWEep:MODE?'.format(channel))
 
             if result != 'HOLD':
                 raise InstrIOError(cleandoc('''PNA did not set correctly the
@@ -815,7 +796,7 @@ class AgilentPNA(VisaInstrument):
     def defined_channels(self):
         """
         """
-        channels = self.ask('SYSTem:CHANnels:CATalog?')
+        channels = self.query('SYSTem:CHANnels:CATalog?')
         if channels:
             defined_channels = [int(channel)
                                 for channel in channels[1:-1].split(',')]
@@ -829,7 +810,7 @@ class AgilentPNA(VisaInstrument):
     def windows(self):
         """
         """
-        windows = self.ask('SYSTem:WINDows:CATalog?')
+        windows = self.query('SYSTem:WINDows:CATalog?')
         if windows:
             aux = [int(channel) for channel in windows[1:-1].split(',')]
             return aux
@@ -842,7 +823,7 @@ class AgilentPNA(VisaInstrument):
     def trigger_scope(self):
         """
         """
-        scope = self.ask('TRIGger:SEQuence:SCOPe?')
+        scope = self.query('TRIGger:SEQuence:SCOPe?')
         if scope:
             return scope
         else:
@@ -855,7 +836,7 @@ class AgilentPNA(VisaInstrument):
         """
         """
         self.write('TRIGger:SEQuence:SCOPe {}'.format(value))
-        result = self.ask('TRIGger:SEQuence:SCOPe?')
+        result = self.query('TRIGger:SEQuence:SCOPe?')
 
         if result.lower() != value.lower()[:len(result)]:
             raise InstrIOError(cleandoc('''PNA did not set correctly the
@@ -866,7 +847,7 @@ class AgilentPNA(VisaInstrument):
     def trigger_source(self):
         """
         """
-        scope = self.ask('TRIGger:SEQuence:SOURce?')
+        scope = self.query('TRIGger:SEQuence:SOURce?')
         if scope:
             return scope
         else:
@@ -879,7 +860,7 @@ class AgilentPNA(VisaInstrument):
         """
         """
         self.write('TRIGger:SEQuence:SOURce {}'.format(value))
-        result = self.ask('TRIGger:SEQuence:SOURce?')
+        result = self.query('TRIGger:SEQuence:SOURce?')
 
         if result.lower() != value.lower()[:len(result)]:
             raise InstrIOError(cleandoc('''PNA did not set correctly the
@@ -890,7 +871,7 @@ class AgilentPNA(VisaInstrument):
     def data_format(self):
         """
         """
-        data_format = self.ask('FORMAT:DATA?')
+        data_format = self.query('FORMAT:DATA?')
         if data_format:
             return data_format
         else:
@@ -903,7 +884,7 @@ class AgilentPNA(VisaInstrument):
         """
         """
         self.write('FORMAT:DATA {}'.format(value))
-        result = self.ask('FORMAT:DATA?')
+        result = self.query('FORMAT:DATA?')
 
         if result.lower() != value.lower()[:len(result)]:
             raise InstrIOError(cleandoc('''PNA did not set correctly the

--- a/exopy_hqc_legacy/instruments/drivers/visa/agilent_psa.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/agilent_psa.py
@@ -410,7 +410,7 @@ class AgilentPSA(VisaInstrument):
         if self.mode == 'WAV':
             sweep = self.query('SENS:WAV:SWEEP:TIME?')
             if sweep:
-                return float(swee)
+                return float(sweep)
             else:
                 raise InstrIOError(cleandoc('''Agilent PSA did not return the
                     sweep time'''))

--- a/exopy_hqc_legacy/instruments/drivers/visa/anapico.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/anapico.py
@@ -75,9 +75,9 @@ class Anapico(VisaInstrument):
         """Frequency of the output signal.
 
         """
-        freq = self.ask_for_values('FREQ?')
+        freq = self.query('FREQ?')
         if freq:
-            return freq[0]
+            return float(freq)
         else:
             raise InstrIOError
 
@@ -89,15 +89,16 @@ class Anapico(VisaInstrument):
         """
         unit = self.frequency_unit
         self.write('FREQ {}{}'.format(value, unit))
-        result = self.ask_for_values('FREQ?')
+        result = self.query('FREQ?')
         if result:
+            result = float(result)
             if unit == 'GHz':
-                result[0] /= 1e9
+                result /= 1e9
             elif unit == 'MHz':
-                result[0] /= 1e6
+                result /= 1e6
             elif unit == 'KHz':
-                result[0] /= 1e3
-            if abs(result[0] - value) > 1e-12:
+                result /= 1e3
+            if abs(result - value) > 1e-12:
                 mes = 'Instrument did not set correctly the frequency.'
                 raise InstrIOError(mes)
 
@@ -107,9 +108,9 @@ class Anapico(VisaInstrument):
         """Power of the output signal.
 
         """
-        power = self.ask_for_values('POWER?')[0]
-        if power is not None:
-            return power
+        power = self.query('POWER?')
+        if power:
+            return float(power)
         else:
             raise InstrIOError
 
@@ -120,7 +121,7 @@ class Anapico(VisaInstrument):
 
         """
         self.write('POWER {}'.format(value))
-        result = self.ask_for_values('POWER?')[0]
+        result = float(self.query('POWER?'))
         if abs(result - value) > 1e-4:
             raise InstrIOError('Instrument did not set correctly the power')
 
@@ -130,11 +131,11 @@ class Anapico(VisaInstrument):
         """Output state of the source.
 
         """
-        output = self.ask_for_values(':OUTP?')
-        if output is not None:
-            return bool(output[0])
+        output = self.query(':OUTP?')
+        if output:
+            return bool(int(output))
         else:
-            mes = 'PSG signal generator did not return its output'
+            mes = 'Anapico signal generator did not return its output'
             raise InstrIOError(mes)
 
     @output.setter
@@ -147,12 +148,12 @@ class Anapico(VisaInstrument):
         off = re.compile('off', re.IGNORECASE)
         if on.match(value) or value == 1:
             self.write(':OUTPUT ON')
-            if self.ask(':OUTPUT?') != '1':
+            if self.query(':OUTPUT?') != '1':
                 raise InstrIOError(cleandoc('''Instrument did not set correctly
                                         the output'''))
         elif off.match(value) or value == 0:
             self.write(':OUTPUT OFF')
-            if self.ask(':OUTPUT?') != '0':
+            if self.query(':OUTPUT?') != '0':
                 raise InstrIOError(cleandoc('''Instrument did not set correctly
                                         the output'''))
         else:
@@ -166,11 +167,11 @@ class Anapico(VisaInstrument):
         """Pulse modulation getter method
 
         """
-        pm_state = self.ask_for_values('SOURce:PULM:STATE?')
-        if pm_state is not None:
-            return bool(pm_state[0])
+        pm_state = self.query('SOURce:PULM:STATE?')
+        if pm_state:
+            return bool(pm_state)
         else:
-            mes = 'Signal generator did not return its pulse modulation state'
+            mes = 'Anapico signal generator did not return its pulse modulation state'
             raise InstrIOError(mes)
 
     @pm_state.setter
@@ -187,12 +188,12 @@ class Anapico(VisaInstrument):
         off = re.compile('off', re.IGNORECASE)
         if on.match(value) or value == 1:
             self.write('SOURce:PULM:STATE ON')
-            if self.ask('SOURce:PULM:STATE?') != '1':
+            if self.query('SOURce:PULM:STATE?') != '1':
                 raise InstrIOError(cleandoc('''Instrument did not set correctly
                                         the pulse modulation state'''))
         elif off.match(value) or value == 0:
             self.write('SOURce:PULM:STATE OFF')
-            if self.ask('SOURce:PULM:STATE?') != '0':
+            if self.query('SOURce:PULM:STATE?') != '0':
                 raise InstrIOError(cleandoc('''Instrument did not set correctly
                                         the pulse modulation state'''))
         else:

--- a/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_cs4.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_cs4.py
@@ -80,14 +80,14 @@ class CS4(VisaInstrument):
         """Read the current value of the output field.
 
         """
-        return float(self.ask('IOUT?').strip(' T'))
+        return float(self.query('IOUT?').strip(' T'))
 
     @secure_communication()
     def read_persistent_field(self):
         """Read the current value of the persistent field.
 
         """
-        return float(self.ask('IMAG?').strip(' T'))
+        return float(self.query('IMAG?').strip(' T'))
 
     def is_target_reached(self):
         """Check whether the target field has been reached.
@@ -140,7 +140,7 @@ class CS4(VisaInstrument):
         coil.
 
         """
-        heat = self.ask('PSHTR?').strip()
+        heat = self.query('PSHTR?').strip()
         try:
             return _GET_HEATER_DICT[heat]
         except KeyError:
@@ -160,7 +160,7 @@ class CS4(VisaInstrument):
 
         """
         # converted from A/s to T/min
-        rate = float(self.ask('RATE? 0'))
+        rate = float(self.query('RATE? 0'))
         return rate * (60 * self.field_current_ratio)
 
     @field_sweep_rate.setter
@@ -177,7 +177,7 @@ class CS4(VisaInstrument):
         (T/min).
 
         """
-        rate = float(self.ask('RATE? 3'))
+        rate = float(self.query('RATE? 3'))
         return rate * (60 * self.field_current_ratio)
 
     @fast_sweep_rate.setter
@@ -193,7 +193,7 @@ class CS4(VisaInstrument):
 
         """
         # in T
-        return float(self.ask('ULIM?').strip(' T'))
+        return float(self.query('ULIM?').strip(' T'))
 
     @target_field.setter
     @secure_communication()
@@ -210,7 +210,7 @@ class CS4(VisaInstrument):
         """Last known value of the magnet field.
 
         """
-        return float(self.ask('IMAG?').strip(' T'))
+        return float(self.query('IMAG?').strip(' T'))
 
     @instrument_property
     @secure_communication()
@@ -218,7 +218,7 @@ class CS4(VisaInstrument):
         """Current activity of the power supply (idle, ramping).
 
         """
-        return self.ask('SWEEP?').strip()
+        return self.query('SWEEP?').strip()
 
     @activity.setter
     @secure_communication()

--- a/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_g4.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_g4.py
@@ -47,14 +47,14 @@ class C4G(CS4):
         """Read the current value of the output field.
 
         """
-        return float(self.ask('IOUT?').strip(' kG')) / 10
+        return float(self.query('IOUT?').strip(' kG')) / 10
 
     @secure_communication()
     def read_persistent_field(self):
         """Read the current value of the persistent field.
 
         """
-        return float(self.ask('IMAG?').strip(' kG')) / 10
+        return float(self.query('IMAG?').strip(' kG')) / 10
 
     @instrument_property
     @secure_communication()
@@ -63,7 +63,7 @@ class C4G(CS4):
 
         """
         # in T
-        return float(self.ask('ULIM?').strip(' kG')) / 10
+        return float(self.query('ULIM?').strip(' kG')) / 10
 
     @target_field.setter
     @secure_communication()
@@ -90,7 +90,7 @@ class C4G(CS4):
         (T/min).
 
         """
-        rate = float(self.ask('RATE? 5'))
+        rate = float(self.query('RATE? 5'))
         return rate * (60 * self.field_current_ratio)
 
     @fast_sweep_rate.setter

--- a/exopy_hqc_legacy/instruments/drivers/visa/keithley_multimeters.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/keithley_multimeters.py
@@ -69,7 +69,7 @@ class Keithley2000(VisaInstrument):
         """Function setter
 
         """
-        value = self.ask('FUNCtion?')
+        value = self.query('FUNCtion?')
         if value:
             return value
         else:
@@ -80,7 +80,7 @@ class Keithley2000(VisaInstrument):
     def function(self, value):
         self.write('FUNCtion "{}"'.format(value))
         # The Keithley returns "VOLT:DC" needs to remove the quotes
-        if not(self.ask('FUNCtion?')[1:-1].lower() == value.lower()):
+        if not(self.query('FUNCtion?')[1:-1].lower() == value.lower()):
             raise InstrIOError('Keithley2000: Failed to set function')
 
     @secure_communication()
@@ -96,9 +96,9 @@ class Keithley2000(VisaInstrument):
         if self.function != 'VOLT:DC':
             self.function = 'VOLT:DC'
 
-        value = self.ask_for_values('FETCh?')
+        value = self.query('FETCh?')
         if value:
-            return value[0]
+            return float(value)
         else:
             raise InstrIOError('Keithley2000: DC voltage measure failed')
 
@@ -115,9 +115,9 @@ class Keithley2000(VisaInstrument):
         if self.function != 'VOLT:AC':
             self.function = 'VOLT:AC'
 
-        value = self.ask_for_values('FETCh?')
+        value = self.query('FETCh?')
         if value:
-            return value[0]
+            return float(value)
         else:
             raise InstrIOError('Keithley2000: AC voltage measure failed')
 
@@ -135,9 +135,9 @@ class Keithley2000(VisaInstrument):
         if self.function != 'RES':
             self.function = 'RES'
 
-        value = self.ask_for_values('FETCh?')
+        value = self.query('FETCh?')
         if value:
-            return value[0]
+            return float(value)
         else:
             raise InstrIOError('Keithley2000: Resistance measure failed')
 
@@ -154,9 +154,9 @@ class Keithley2000(VisaInstrument):
         if self.function != 'CURR:DC':
             self.function = 'CURR:DC'
 
-        value = self.ask_for_values('FETCh?')
+        value = self.query('FETCh?')
         if value:
-            return value[0]
+            return float(value)
         else:
             raise InstrIOError('Keithley2000: DC current measure failed')
 
@@ -173,9 +173,9 @@ class Keithley2000(VisaInstrument):
         if self.function != 'CURR:AC':
             self.function = 'CURR:AC'
 
-        value = self.ask_for_values('FETCh?')
+        value = self.query('FETCh?')
         if value:
-            return value[0]
+            return float(value)
         else:
             raise InstrIOError('Keithley2000: AC current measure failed')
 
@@ -187,6 +187,6 @@ class Keithley2000(VisaInstrument):
         corrupted and should be cleared.
 
         """
-        val = ('{0:08b}'.format(int(self.ask('*ESR'))))[::-1]
+        val = ('{0:08b}'.format(int(self.query('*ESR'))))[::-1]
         if val:
             return val[6]

--- a/exopy_hqc_legacy/instruments/drivers/visa/le_croy_64xi.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/le_croy_64xi.py
@@ -60,8 +60,8 @@ class LeCroyChannel(BaseInstrument):
         with self.secure():
             # check if the channel studied is not a trace channel
             if len(self._channel) == 1:
-                result = self._LeCroy64Xi.ask('C{}:VDIV?'
-                                              .format(self._channel))
+                result = self._LeCroy64Xi.query('C{}:VDIV?'
+                                                .format(self._channel))
                 result = result.replace('C{}:VDIV '.format(self._channel), '')
                 return result
             else:
@@ -86,8 +86,8 @@ class LeCroyChannel(BaseInstrument):
             if len(self._channel) == 1:
                 self._LeCroy64Xi.write('C{}:VDIV {}'
                                        .format(self._channel, value))
-                result = self._LeCroy64Xi.ask('C{}:VDIV?'
-                                              .format(self._channel))
+                result = self._LeCroy64Xi.query('C{}:VDIV?'
+                                                .format(self._channel))
                 result = result.replace('C{}:VDIV '.format(self._channel), '')
                 result = result.replace('V', '')
                 result = float(result)
@@ -122,7 +122,7 @@ class LeCroyChannel(BaseInstrument):
         with self.secure():
             # check if the channel studied is not a trace channel
             if len(self._channel) == 1:
-                result = self._LeCroy64Xi.ask('C{}:OFST?'
+                result = self._LeCroy64Xi.query('C{}:OFST?'
                                               .format(self._channel))
                 result = result.replace('C{}:OFST '.format(self._channel), '')
                 result = result.replace('V', '')
@@ -149,7 +149,7 @@ class LeCroyChannel(BaseInstrument):
             if len(self._channel) == 1:
                 self._LeCroy64Xi.write('C{}:OFST {}'
                                        .format(self._channel, value))
-                result = self._LeCroy64Xi.ask('C{}:OFST?'
+                result = self._LeCroy64Xi.query('C{}:OFST?'
                                               .format(self._channel))
                 result = result.replace('C{}:OFST '.format(self._channel), '')
                 result = result.replace('V', '')
@@ -186,9 +186,9 @@ class LeCroyChannel(BaseInstrument):
             # check if the channel studied is not a trace channel
             if len(self._channel) == 1:
                 cmd = 'VBS? "return=app.Acquisition.C{}.Out.Result.Sweeps"'
-                result = instr.ask_for_values(cmd.format(self._channel))
+                result = instr.query(cmd.format(self._channel))
                 if result:
-                    return result[0]
+                    return float(result)
                 else:
                     raise InstrIOError('LeCraoy failed to return sweep')
             else:
@@ -243,13 +243,13 @@ class LeCroyChannel(BaseInstrument):
         '''
         if hires in ('True', 'Yes'):
             self._LeCroy64Xi.write('CFMT DEF9,WORD,BIN')
-            result = self._LeCroy64Xi.ask('CFMT?')
+            result = self._LeCroy64Xi.query('CFMT?')
             if result != 'CFMT DEF9,WORD,BIN':
                 mes = 'Instrument did not set the WORD mode'
                 raise InstrIOError(mes)
         elif hires in ('No', 'False'):
             self._LeCroy64Xi.write('CFMT DEF9,BYTE,BIN')
-            result = self._LeCroy64Xi.ask('CFMT?')
+            result = self._LeCroy64Xi.query('CFMT?')
             if result != 'CFMT DEF9,BYTE,BIN':
                 mes = 'Instrument did not set the BYTE mode'
                 raise InstrIOError(mes)
@@ -258,9 +258,9 @@ class LeCroyChannel(BaseInstrument):
             raise InstrIOError(mes)
 
         if len(self._channel) == 1:
-            databyte = bytearray(self._LeCroy64Xi.ask('C{}:WF?'.format(self._channel)))
+            databyte = bytearray(self._LeCroy64Xi.query('C{}:WF?'.format(self._channel)))
         else:
-            databyte = bytearray(self._LeCroy64Xi.ask('{}:WF?'.format(self._channel)))
+            databyte = bytearray(self._LeCroy64Xi.query('{}:WF?'.format(self._channel)))
 
         databyte = databyte[self.descriptor_start:]
         self.data['COMM_TYPE'] = struct.unpack('<b', databyte[32:33])  # /COMM_TYPE: enum ; chosen by remote command COMM_FORMAT
@@ -516,13 +516,13 @@ class LeCroyChannel(BaseInstrument):
         '''
         if hires in ('True', 'Yes'):
             self._LeCroy64Xi.write('CFMT DEF9,WORD,BIN')
-            result = self._LeCroy64Xi.ask('CFMT?')
+            result = self._LeCroy64Xi.query('CFMT?')
             if result != 'CFMT DEF9,WORD,BIN':
                 mes = 'Instrument did not set the WORD mode'
                 raise InstrIOError(mes)
         elif hires in ('No', 'False'):
             self._LeCroy64Xi.write('CFMT DEF9,BYTE,BIN')
-            result = self._LeCroy64Xi.ask('CFMT?')
+            result = self._LeCroy64Xi.query('CFMT?')
             if result != 'CFMT DEF9,BYTE,BIN':
                 mes = 'Instrument did not set the BYTE mode'
                 raise InstrIOError(mes)
@@ -531,9 +531,9 @@ class LeCroyChannel(BaseInstrument):
             raise InstrIOError(mes)
 
         if len(self._channel) == 1:
-            databyte = bytearray(self._LeCroy64Xi.ask('C{}:WF?'.format(self._channel)))
+            databyte = bytearray(self._LeCroy64Xi.query('C{}:WF?'.format(self._channel)))
         else:
-            databyte = bytearray(self._LeCroy64Xi.ask('{}:WF?'.format(self._channel)))
+            databyte = bytearray(self._LeCroy64Xi.query('{}:WF?'.format(self._channel)))
 
         databyte = databyte[self.descriptor_start:]
 
@@ -800,7 +800,7 @@ class LeCroy64Xi(VisaInstrument):
         ''' Method to get the trigger mode
 
         '''
-        mode = self.ask('TRMD?')
+        mode = self.query('TRMD?')
         if mode is not None:
             mode = mode.replace('TRMD ', '')
             return mode
@@ -817,7 +817,7 @@ class LeCroy64Xi(VisaInstrument):
         {'AUTO','NORM','SINGLE','STOP'}
         '''
         self.write('TRMD {}'.format(value))
-        result = self.ask('TRMD?')
+        result = self.query('TRMD?')
         result = result.replace('TRMD ', '')
         if result != value:
             raise InstrIOError(cleandoc('''Instrument did not set correctly
@@ -841,7 +841,7 @@ class LeCroy64Xi(VisaInstrument):
         ''' Method to know if the instrument is in auto calibrate mode
 
         '''
-        answer = self.ask('ACAL?')
+        answer = self.query('ACAL?')
         if answer is not None:
             answer = answer.replace('ACAL ', '')
             return answer
@@ -859,14 +859,14 @@ class LeCroy64Xi(VisaInstrument):
         '''
         if value in ('ON', 'Yes'):
             self.write('ACAL ON')
-            result = self.ask('ACAL?')
+            result = self.query('ACAL?')
             result = result.replace('ACAL ', '')
             if result != 'ON':
                 raise InstrIOError(cleandoc('''Instrument did not set correctly
                                             the auto calibrate mode'''))
         elif value in ('OFF', 'No'):
             self.write('ACAL OFF')
-            result = self.ask('ACAL?')
+            result = self.query('ACAL?')
             result = result.replace('ACAL ', '')
             if result != 'OFF':
                 raise InstrIOError(cleandoc('''Instrument did not set correctly
@@ -886,7 +886,7 @@ class LeCroy64Xi(VisaInstrument):
         Output:
         value (str) : Timebase in S
         '''
-        result = self.ask('TDIV?')
+        result = self.query('TDIV?')
         result = result.replace('TDIV ', '')
         if result is not None:
             return result
@@ -909,7 +909,7 @@ class LeCroy64Xi(VisaInstrument):
         '''
 
         self.write('TDIV {}'.format(value))
-        result = self.ask('TDIV?')
+        result = self.query('TDIV?')
         result = result.replace('TDIV ', '')
         result = result.replace('S', '')
         result = float(result)
@@ -937,7 +937,7 @@ class LeCroy64Xi(VisaInstrument):
         result(float) : maximum memory size in Samples
         '''
 
-        result = self.ask('MSIZ?')
+        result = self.query('MSIZ?')
         result = result.replace('MSIZ ', '')
         result = result.replace(' SAMPLE', '')
         return float(result)
@@ -952,7 +952,7 @@ class LeCroy64Xi(VisaInstrument):
         None
         '''
         self.write('MSIZ {}'.format(msize))
-        result = self.ask('MSIZ?')
+        result = self.query('MSIZ?')
         result = result.replace('MSIZ ', '')
         result = float(result.replace(' SAMPLE', ''))
         if result != float(msize):
@@ -1002,5 +1002,3 @@ class LeCroy64Xi(VisaInstrument):
         None
         '''
         self.write('CLSW')
-
-DRIVERS = {'LeCroy64Xi': LeCroy64Xi}

--- a/exopy_hqc_legacy/instruments/drivers/visa/lock_in_sr72_series.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/lock_in_sr72_series.py
@@ -62,12 +62,12 @@ class LockInSR7265(VisaInstrument):
         independent values if the instrument is queried too often.
 
         """
-        value = self.ask_for_values('X.')
+        value = self.query('X.')
         status = self._check_status()
         if status != 'OK' or not value:
             raise InstrIOError('The command did not complete correctly')
         else:
-            return value[0]
+            return float(value)
 
     @secure_communication()
     def read_y(self):
@@ -78,12 +78,12 @@ class LockInSR7265(VisaInstrument):
         independent values if the instrument is queried too often.
 
         """
-        value = self.ask_for_values('Y.')
+        value = self.query('Y.')
         status = self._check_status()
         if status != 'OK' or not value:
             raise InstrIOError('The command did not complete correctly')
         else:
-            return value[0]
+            return float(value)
 
     @secure_communication()
     def read_xy(self):
@@ -94,7 +94,7 @@ class LockInSR7265(VisaInstrument):
         independent values if the instrument is queried too often.
 
         """
-        values = self.ask_for_values('XY.')
+        values = self.query_ascii_values('XY.')
         status = self._check_status()
         if status != 'OK' or not values:
             raise InstrIOError('The command did not complete correctly')
@@ -110,12 +110,12 @@ class LockInSR7265(VisaInstrument):
         independent values if the instrument is queried too often.
 
         """
-        value = self.ask_for_values('MAG.')
+        value = self.query('MAG.')
         status = self._check_status()
         if status != 'OK' or not value:
             return InstrIOError('The command did not complete correctly')
         else:
-            return value[0]
+            return float(value)
 
     @secure_communication()
     def read_phase(self):
@@ -126,12 +126,12 @@ class LockInSR7265(VisaInstrument):
         independent values if the instrument is queried too often.
 
         """
-        value = self.ask_for_values('PHA.')
+        value = self.query('PHA.')
         status = self._check_status()
         if status != 'OK' or not value:
             raise InstrIOError('The command did not complete correctly')
         else:
-            return value[0]
+            return float(value)
 
     @secure_communication()
     def read_amp_and_phase(self):
@@ -142,7 +142,7 @@ class LockInSR7265(VisaInstrument):
         independent values if the instrument is queried too often.
 
         """
-        values = self.ask_for_values('MP.')
+        values = self.query_ascii_values('MP.')
         status = self._check_status()
         if status != 'OK' or not values:
             raise InstrIOError('The command did not complete correctly')
@@ -155,7 +155,7 @@ class LockInSR7265(VisaInstrument):
         Read the value of the status byte to determine if the last command
         executed properly
         """
-        bites = self.ask('ST')
+        bites = self.query('ST')
         status_byte = ('{0:08b}'.format(ord(bites[0])))[::-1]
         if not status_byte[0]:
             return 'Command went wrong'

--- a/exopy_hqc_legacy/instruments/drivers/visa/lock_in_sr830.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/lock_in_sr830.py
@@ -62,11 +62,11 @@ class LockInSR830(VisaInstrument):
         independent values if the instrument is queried too often.
 
         """
-        value = self.ask_for_values('OUTP?1')
+        value = self.query('OUTP?1')
         if not value:
             raise InstrIOError('The command did not complete correctly')
         else:
-            return value[0]
+            return float(value)
 
     @secure_communication()
     def read_y(self):
@@ -77,11 +77,11 @@ class LockInSR830(VisaInstrument):
         independent values if the instrument is queried too often.
 
         """
-        value = self.ask_for_values('OUTP?2')
+        value = self.query('OUTP?2')
         if not value:
             raise InstrIOError('The command did not complete correctly')
         else:
-            return value[0]
+            return float(value)
 
     @secure_communication()
     def read_xy(self):
@@ -92,7 +92,7 @@ class LockInSR830(VisaInstrument):
         independent values if the instrument is queried too often.
 
         """
-        values = self.ask_for_values('SNAP?1,2')
+        values = self.query_ascii_values('SNAP?1,2')
         if not values:
             raise InstrIOError('The command did not complete correctly')
         else:
@@ -107,11 +107,11 @@ class LockInSR830(VisaInstrument):
         independent values if the instrument is queried too often.
 
         """
-        value = self.ask_for_values('OUTP?3')
+        value = self.query('OUTP?3')
         if not value:
             return InstrIOError('The command did not complete correctly')
         else:
-            return value[0]
+            return float(value)
 
     @secure_communication()
     def read_phase(self):
@@ -122,11 +122,11 @@ class LockInSR830(VisaInstrument):
         independent values if the instrument is queried too often.
 
         """
-        value = self.ask_for_values('OUTP?4')
+        value = self.query('OUTP?4')
         if not value:
             raise InstrIOError('The command did not complete correctly')
         else:
-            return value[0]
+            return float(value)
 
     @secure_communication()
     def read_amp_and_phase(self):
@@ -137,7 +137,7 @@ class LockInSR830(VisaInstrument):
         independent values if the instrument is queried too often.
 
         """
-        values = self.ask_for_values('SNAP?3,4')
+        values = self.query_ascii_values('SNAP?3,4')
         if not values:
             raise InstrIOError('The command did not complete correctly')
         else:

--- a/exopy_hqc_legacy/instruments/drivers/visa/oxford_ips.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/oxford_ips.py
@@ -169,12 +169,12 @@ class IPS12010(VisaInstrument):
 
         """
         if mode == 'AMPS':
-            result = self.ask('M8')
+            result = self.query('M8')
             if result.startswith('?'):
                 raise InstrIOError(cleandoc('''IPS120-10 did not set the
                     heater mode to {}'''.format(mode)))
         elif mode == 'TESLA':
-            result = self.ask('M9')
+            result = self.query('M9')
             if result.startswith('?'):
                 raise InstrIOError(cleandoc('''IPS120-10 did not set the
                     heater mode to {}'''.format(mode)))
@@ -210,7 +210,7 @@ class IPS12010(VisaInstrument):
         """
         par = _PARAMETER_DICT.get(parameter, None)
         if par:
-            return self.ask('R{}'.format(par))[1:]
+            return self.query('R{}'.format(par))[1:]
         else:
             raise ValueError(cleandoc(''' Invalid parameter {} sent to
                 IPS120-10 read_parameter method'''.format(parameter)))
@@ -246,12 +246,12 @@ class IPS12010(VisaInstrument):
 
         """
         if state == 'ON':
-            result = self.ask('H1')
+            result = self.query('H1')
             if result.startswith('?'):
                 raise InstrIOError(cleandoc('''IPS120-10 did not set the
                     heater state to {}'''.format(state)))
         elif state == 'OFF':
-            result = self.ask('H0')
+            result = self.query('H0')
             if result.startswith('?'):
                 raise InstrIOError(cleandoc('''IPS120-10 did not set the
                     heater state to {}'''.format(state)))
@@ -281,7 +281,7 @@ class IPS12010(VisaInstrument):
         """
         value = _CONTROL_DICT.get(control, None)
         if value:
-            result = self.ask('C{}'.format(value))
+            result = self.query('C{}'.format(value))
             if result.startswith('?'):
                 raise InstrIOError(cleandoc('''IPS120-10 did not set the
                     control to {}'''.format(control)))
@@ -306,7 +306,7 @@ class IPS12010(VisaInstrument):
         """
         par = _ACTIVITY_DICT.get(value, None)
         if par:
-            result = self.ask('A{}'.format(par))
+            result = self.query('A{}'.format(par))
             if result.startswith('?'):
                 raise InstrIOError(cleandoc('''IPS120-10 did not set the
                     activity to {}'''.format(value)))
@@ -327,7 +327,7 @@ class IPS12010(VisaInstrument):
         """Current the source tries to reach when going to set point.
 
         """
-        result = self.ask("I{}".format(target))
+        result = self.query("I{}".format(target))
         if result.startswith('?'):
             raise InstrIOError(cleandoc('''IPS120-10 did not set the
                     target current to {}'''.format(target)))
@@ -346,7 +346,7 @@ class IPS12010(VisaInstrument):
 
         """
         # amps/min
-        result = self.ask("S{}".format(rate))
+        result = self.query("S{}".format(rate))
         if result.startswith('?'):
             raise InstrIOError(cleandoc('''IPS120-10 did not set the
                     rate field to {}'''.format(rate)))
@@ -364,7 +364,7 @@ class IPS12010(VisaInstrument):
         """Field the source tries to reach when going to set point.
 
         """
-        result = self.ask("J{}".format(target))
+        result = self.query("J{}".format(target))
         if result.startswith('?'):
             raise InstrIOError(cleandoc('''IPS120-10 did not set the
                     target field to {}'''.format(target)))
@@ -383,7 +383,7 @@ class IPS12010(VisaInstrument):
 
         """
         # tesla/min
-        result = self.ask("T{}".format(rate))
+        result = self.query("T{}".format(rate))
         if result.startswith('?'):
             raise InstrIOError(cleandoc('''IPS120-10 did not set the
                     rate field to {}'''.format(rate)))
@@ -402,7 +402,7 @@ class IPS12010(VisaInstrument):
 
         """
         # tesla/min
-        result = self.ask("T{}".format(rate))
+        result = self.query("T{}".format(rate))
         if result.startswith('?'):
             raise InstrIOError(cleandoc('''IPS120-10 did not set the
                     rate field to {}'''.format(rate)))
@@ -412,7 +412,7 @@ class IPS12010(VisaInstrument):
         """Get the status of the instrument.
 
         """
-        status = self.ask('X')
+        status = self.query('X')
         if status:
             return status.strip()
         else:

--- a/exopy_hqc_legacy/instruments/drivers/visa/rohde_and_schwarz_zva24.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/rohde_and_schwarz_zva24.py
@@ -15,13 +15,6 @@ import numpy as np
 import re
 from textwrap import fill
 
-try:
-    from visa import ascii, single, double
-except ImportError:
-    ascii = 2
-    single = 1
-    double = 3
-
 from ..driver_tools import (BaseInstrument, InstrIOError, InstrError,
                             secure_communication, instrument_property)
 from ..visa_tools import VisaInstrument
@@ -95,13 +88,13 @@ class ZVA24Channel(BaseInstrument):
 
         data_request = 'CALCulate{}:DATA? FDATA'.format(self._channel)
         if self._pna.data_format == 'REAL,32':
-            data = self._pna.ask_for_values(data_request, single)
+            data = self._pna.query_binary_values(data_request, 'f')
 
         elif self._pna.data_format == 'REAL,64':
-            data = self._pna.ask_for_values(data_request, double)
+            data = self._pna.query_binary_values(data_request, 'd')
 
         else:
-            data = self._pna.ask_for_values(data_request, ascii)
+            data = self._pna.query_ascii_values(data_request)
 
         if data:
             return np.array(data)
@@ -133,13 +126,13 @@ class ZVA24Channel(BaseInstrument):
 
         data_request = 'CALCulate{}:DATA? SDATA'.format(self._channel)
         if self._pna.data_format == 'REAL,32':
-            data = self._pna.ask_for_values(data_request, single)
+            data = self._pna.query_binary_values(data_request, 'f')
 
         elif self._pna.data_format == 'REAL,64':
-            data = self._pna.ask_for_values(data_request, double)
+            data = self._pna.query_binary_values(data_request, 'd')
 
         else:
-            data = self._pna.ask_for_values(data_request, ascii)
+            data = self._pna.query_ascii_values(data_request)
 
         if not meas_name:
             meas_name = self.selected_measure
@@ -181,7 +174,7 @@ class ZVA24Channel(BaseInstrument):
         for i in range(0, int(self.average_count)):
             while True:
                 try:
-                    done = self._pna.ask_for_values('*OPC?')[0]
+                    done = self._pna.query('*OPC?')
                     break
                 except Exception:
                     self._pna.timeout = self._pna.timeout*2
@@ -199,7 +192,7 @@ class ZVA24Channel(BaseInstrument):
         """
         """
         request = 'CALCulate{}:PARameter:CATalog?'
-        meas = self._pna.ask(request.format(self._channel))
+        meas = self._pna.query(request.format(self._channel))
 
         if meas:
             if meas == "''":
@@ -225,7 +218,7 @@ class ZVA24Channel(BaseInstrument):
                                            meas_name.replace(':', '_'),
                                            param))
 
-        meas = self._pna.ask(catalog_request.format(self._channel))
+        meas = self._pna.query(catalog_request.format(self._channel))
         if meas:
             if param not in meas:
                 mess = cleandoc('''The Pna did not create the
@@ -241,7 +234,7 @@ class ZVA24Channel(BaseInstrument):
         self._pna.write(
             "CALCulate{}:PARameter:DELete '{}'".format(self._channel,
                                                        meas_name))
-        meas = self._pna.ask('CALCulate{}:PARameter:CATalog:SENDed?'.format(
+        meas = self._pna.query('CALCulate{}:PARameter:CATalog:SENDed?'.format(
                              self._channel))
         if meas:
             if meas_name in meas:
@@ -270,7 +263,7 @@ class ZVA24Channel(BaseInstrument):
             self.selected_measure = meas_name
         self._pna.write('CALCulate{}:FORMat {}'.format(self._channel,
                                                        meas_format))
-        res = self._pna.ask('CALCulate{}:FORMat?'.format(self._channel))
+        res = self._pna.query('CALCulate{}:FORMat?'.format(self._channel))
         if meas_name and selected_meas:
             self.selected_measure = selected_meas
         else:
@@ -290,7 +283,7 @@ class ZVA24Channel(BaseInstrument):
         self._pna.write("DISPlay:WINDow{}:TRACe{}:EFEed '{}'".
                         format(window_num, 1, meas_name.replace(':', '_')))
 
-        traces = self._pna.ask('DISPlay:WINDow{}:TRACe1:CATalog?'.
+        traces = self._pna.query('DISPlay:WINDow{}:TRACe1:CATalog?'.
                                format(window_num))
         if str(meas_name.replace(':', '_')) not in traces:
             raise InstrIOError(cleandoc('''The Pna did not bind the meas {}
@@ -344,10 +337,10 @@ class ZVA24Channel(BaseInstrument):
     def frequency(self):
         """Frequency getter method
         """
-        freq = self._pna.ask_for_values('SENS{}:FREQuency:CENTer?'.format(
+        freq = self._pna.query('SENS{}:FREQuency:CENTer?'.format(
                                         self._channel))
         if freq:
-            return freq[0]
+            return float(freq)
         else:
             raise InstrIOError(cleandoc('''ZVA24 did not return the
                     channel {} frequency'''.format(self._channel)))
@@ -359,10 +352,10 @@ class ZVA24Channel(BaseInstrument):
         """
         self._pna.write('SENS{}:FREQuency:CENTer {}'.format(self._channel,
                                                             value))
-        result = self._pna.ask_for_values('SENS{}:FREQuency:CENTer?'.format(
+        result = self._pna.query('SENS{}:FREQuency:CENTer?'.format(
                                           self._channel))
         if result:
-            if abs(result[0] - value)/value > 10**-12:
+            if abs(float(result) - value)/value > 10**-12:
                 raise InstrIOError(cleandoc('''ZVA24 did not set correctly the
                     channel {} frequency'''.format(self._channel)))
         else:
@@ -377,10 +370,10 @@ class ZVA24Channel(BaseInstrument):
         WARNING: this command will not work if the trace selection has not been
         made by the software beforehand
         """
-        trace_nb = self._pna.ask_for_values('CALC{}:PAR:MNUM?'.format(
+        trace_nb = self._pna.query('CALC{}:PAR:MNUM?'.format(
             self._channel))
         if trace_nb:
-            return trace_nb[0]
+            return float(trace_nb)
         else:
             raise InstrIOError(cleandoc('''ZVA24 did not return the
                     trace number on channel {} '''.format(self._channel)))
@@ -391,10 +384,10 @@ class ZVA24Channel(BaseInstrument):
         """Current trace number setter method
         """
         self._pna.write('CALC{}:PAR:MNUM {}'.format(self._channel, value))
-        result = self._pna.ask_for_values('CALC{}:PAR:MNUM?'.format(
+        result = self._pna.query('CALC{}:PAR:MNUM?'.format(
                                           self._channel))
         if result:
-            if abs(result[0] - value)/value > 10**-12:
+            if abs(float(result) - value)/value > 10**-12:
                 raise InstrIOError(cleandoc('''ZVA24 could not set the
                     trace number {} on channel {}'''.format(value,
                                                             self._channel)))
@@ -412,24 +405,22 @@ class ZVA24Channel(BaseInstrument):
         sweep_type = self.sweep_type
         sweep_points = self.sweep_points
         if sweep_type == 'LIN':
-            sweep_start = self._pna.ask_for_values(
-                'SENSe{}:FREQuency:STARt?'.format(self._channel))[0]*1e-9
-            sweep_stop = self._pna.ask_for_values(
-                'SENSe{}:FREQuency:STOP?'.format(self._channel))[0]*1e-9
+            sweep_start = float(self._pna.query(
+                'SENSe{}:FREQuency:STARt?'.format(self._channel)))*1e-9
+            sweep_stop = float(self._pna.query(
+                'SENSe{}:FREQuency:STOP?'.format(self._channel)))*1e-9
             return np.linspace(sweep_start, sweep_stop, sweep_points)
         elif sweep_type == 'POW':
-            sweep_start = self._pna.ask_for_values('SOURce{}:POWer:STARt?'
-                                                   .format(self._channel))[0]
-            sweep_stop = self._pna.ask_for_values('SOURce{}:POWer:STOP?'
-                                                  .format(self._channel))[0]
+            sweep_start = float(self._pna.query('SOURce{}:POWer:STARt?'
+                                                .format(self._channel)))
+            sweep_stop = float(self._pna.query('SOURce{}:POWer:STOP?'
+                                               .format(self._channel)))
             return np.linspace(sweep_start, sweep_stop, sweep_points)
         elif sweep_type == 'LOG':
-            sweep_start = self._pna.ask_for_values(
-                            'SENSe{}:FREQuency:STARt?'
-                            .format(self._channel))[0]*1e-9
-            sweep_stop = self._pna.ask_for_values(
-                            'SENSe{}:FREQuency:STOP?'
-                            .format(self._channel))[0]*1e-9
+            sweep_start = float(self._pna.query('SENSe{}:FREQuency:STARt?'
+                                                .format(self._channel)))*1e-9
+            sweep_stop = float(self._pna.query('SENSe{}:FREQuency:STOP?'
+                                               .format(self._channel)))*1e-9
             return np.logspace(sweep_start, sweep_stop, sweep_points)
         else:
             raise InstrIOError(cleandoc('''Sweep type of ZVA24 not yet
@@ -440,11 +431,11 @@ class ZVA24Channel(BaseInstrument):
     def power(self):
         """Power getter method
         """
-        power = self._pna.ask_for_values('SOUR{}:POWer{}:AMPL?'.format(
+        power = self._pna.query('SOUR{}:POWer{}:AMPL?'.format(
                                          self._channel,
                                          self.port))
         if power:
-            return power[0]
+            return float(power)
         else:
             raise InstrIOError(cleandoc('''ZVA24 did not return the
                     channel {} power for port {}'''.format(self._channel,
@@ -458,11 +449,11 @@ class ZVA24Channel(BaseInstrument):
         self._pna.write('SOUR{}:POWer{}:AMPL {}'.format(self._channel,
                                                         self.port,
                                                         value))
-        result = self._pna.ask_for_values('SOUR{}:POWer{}:AMPL?'.format(
+        result = self._pna.query('SOUR{}:POWer{}:AMPL?'.format(
                                           self._channel,
                                           self.port))
         if result:
-            if abs(result[0] > value) > 10**-12:
+            if abs(float(result) > value) > 10**-12:
                 raise InstrIOError(cleandoc('''ZVA24 did not set correctly the
                     channel {} power for port {}'''.format(self._channel,
                                                            self.port)))
@@ -479,7 +470,7 @@ class ZVA24Channel(BaseInstrument):
         WARNING: this command will not work if the trace selection has not been
         made by the software beforehand
         """
-        meas = self._pna.ask('CALC{}:PARameter:SELect?'.format(self._channel))
+        meas = self._pna.query('CALC{}:PARameter:SELect?'.format(self._channel))
         if meas:
             return meas[1:-1]
         else:
@@ -495,7 +486,7 @@ class ZVA24Channel(BaseInstrument):
         mess0 = "CALC{}:PARameter:SELect '{}'".format(self._channel, value)
         self._pna.write(mess0)
         mess = 'CALC{}:PARameter:SELect?'.format(self._channel)
-        result = self._pna.ask(mess)
+        result = self._pna.query(mess)
         if result:
             if result[1:-1] != value:
                 raise InstrIOError(cleandoc('''ZVA24 did not set correctly the
@@ -506,10 +497,10 @@ class ZVA24Channel(BaseInstrument):
     def if_bandwidth(self):
         """
         """
-        if_bw = self._pna.ask_for_values('SENSe{}:BANDwidth?'.format(
+        if_bw = self._pna.query('SENSe{}:BANDwidth?'.format(
                                          self._channel))
         if if_bw:
-            return if_bw[0]
+            return float(if_bw)
         else:
             raise InstrIOError(cleandoc('''ZVA24 did not return the
                     channel {} IF bandwidth'''.format(self._channel)))
@@ -520,10 +511,10 @@ class ZVA24Channel(BaseInstrument):
         """
         """
         self._pna.write('SENSe{}:BANDwidth {}'.format(self._channel, value))
-        result = self._pna.ask_for_values('SENSe{}:BANDwidth?'.format(
+        result = self._pna.query('SENSe{}:BANDwidth?'.format(
                                           self._channel))
         if result:
-            if abs(result[0] > value) > 10**-12:
+            if abs(float(result) > value) > 10**-12:
                 raise InstrIOError(cleandoc('''ZVA24 did not set correctly the
                     channel {} IF bandwidth'''.format(self._channel)))
         else:
@@ -535,7 +526,7 @@ class ZVA24Channel(BaseInstrument):
     def sweep_mode(self):
         """
         """
-        mode = self._pna.ask('SENSe{}:SWEep:MODE?'.format(self._channel))
+        mode = self._pna.query('SENSe{}:SWEep:MODE?'.format(self._channel))
         if mode:
             return mode
         else:
@@ -548,7 +539,7 @@ class ZVA24Channel(BaseInstrument):
         """
         """
         self._pna.write('SENSe{}:SWEep:MODE {}'.format(self._channel, value))
-        result = self._pna.ask('SENSe{}:SWEep:MODE?'.format(self._channel))
+        result = self._pna.query('SENSe{}:SWEep:MODE?'.format(self._channel))
 
         if result.lower() != value.lower()[:len(result)]:
             raise InstrIOError(cleandoc('''ZVA24 did not set correctly the
@@ -559,7 +550,7 @@ class ZVA24Channel(BaseInstrument):
     def sweep_type(self):
         """
         """
-        sweep_type = self._pna.ask('SENSe{}:SWEep:Type?'.format(self._channel))
+        sweep_type = self._pna.query('SENSe{}:SWEep:Type?'.format(self._channel))
         if sweep_type:
             return sweep_type
         else:
@@ -572,7 +563,7 @@ class ZVA24Channel(BaseInstrument):
         """
         """
         self._pna.write('SENSe{}:SWEep:TYPE {}'.format(self._channel, value))
-        result = self._pna.ask('SENSe{}:SWEep:TYPE?'.format(self._channel))
+        result = self._pna.query('SENSe{}:SWEep:TYPE?'.format(self._channel))
 
         if result.lower() != value.lower()[:len(result)]:
             raise InstrIOError(cleandoc('''ZVA24 did not set correctly the
@@ -583,10 +574,10 @@ class ZVA24Channel(BaseInstrument):
     def sweep_points(self):
         """
         """
-        points = self._pna.ask_for_values('SENSe{}:SWEep:POINts?'.format(
+        points = self._pna.query('SENSe{}:SWEep:POINts?'.format(
                                           self._channel))
         if points:
-            return points[0]
+            return int(points)
         else:
             raise InstrIOError(cleandoc('''ZVA24 did not return the
                     channel {} sweep point number'''.format(self._channel)))
@@ -597,10 +588,10 @@ class ZVA24Channel(BaseInstrument):
         """
         """
         self._pna.write('SENSe{}:SWEep:POINts {}'.format(self._channel, value))
-        result = self._pna.ask_for_values('SENSe{}:SWEep:POINts?'.format(
+        result = self._pna.query('SENSe{}:SWEep:POINts?'.format(
                                           self._channel))
         if result:
-            if result[0] != value:
+            if int(result) != value:
                 raise InstrIOError(cleandoc('''ZVA24 not set correctly the
                     channel {} sweep point number'''.format(self._channel)))
         else:
@@ -612,10 +603,9 @@ class ZVA24Channel(BaseInstrument):
     def sweep_time(self):
         """Sweep time in seconds
         """
-        time = self._pna.ask_for_values('sense{}:sweep:time?'.format(
-            self._channel))
+        time = self._pna.query('sense{}:sweep:time?'.format(self._channel))
         if time:
-            return time[0]
+            return float(time)
         else:
             raise InstrIOError(cleandoc('''ZVA24 did not return the
                     channel {} sweep point number'''.format(self._channel)))
@@ -632,9 +622,9 @@ class ZVA24Channel(BaseInstrument):
     def average_state(self):
         """
         """
-        state = self._pna.ask('SENSe{}:AVERage:STATe?'.format(self._channel))
+        state = self._pna.query('SENSe{}:AVERage:STATe?'.format(self._channel))
         if state:
-            return bool(state)
+            return bool(int(state))
         else:
             raise InstrIOError(cleandoc('''ZVA24 did not return the
                     channel {} average state'''.format(self._channel)))
@@ -644,11 +634,10 @@ class ZVA24Channel(BaseInstrument):
     def average_state(self, value):
         """
         """
-        self._pna.write('SENSe{}:AVERage:STATe {}'.format(self._channel,
-                        value))
-        result = self._pna.ask('SENSe{}:AVERage:STATe?'.format(self._channel))
+        self._pna.write('SENSe{}:AVERage:STATe {}'.format(self._channel, value))
+        result = self._pna.query('SENSe{}:AVERage:STATe?'.format(self._channel))
 
-        if bool(result) != value:
+        if bool(int(result)) != value:
             raise InstrIOError(cleandoc('''ZVA24 did not set correctly the
                 channel {} average state'''.format(self._channel)))
 
@@ -657,10 +646,10 @@ class ZVA24Channel(BaseInstrument):
     def average_count(self):
         """
         """
-        count = self._pna.ask_for_values('SENSe{}:AVERage:COUNt?'.format(
+        count = self._pna.query('SENSe{}:AVERage:COUNt?'.format(
                                          self._channel))
         if count:
-            return count[0]
+            return int(count)
         else:
             raise InstrIOError(cleandoc('''ZVA24 did not return the
                     channel {} average count'''.format(self._channel)))
@@ -671,14 +660,11 @@ class ZVA24Channel(BaseInstrument):
         """
         """
 
-        self._pna.write('SENSe{}:AVERage:COUNt {}'.format(self._channel,
-                        value))
-        self._pna.write('SENSe{}:SWE:GRO:COUNt {}'.format(self._channel,
-                        value))
-        result = self._pna.ask_for_values('SENSe{}:AVERage:COUNt?'.format(
-                                          self._channel))
+        self._pna.write('SENSe{}:AVERage:COUNt {}'.format(self._channel, value))
+        self._pna.write('SENSe{}:SWE:GRO:COUNt {}'.format(self._channel, value))
+        result = self._pna.query('SENSe{}:AVERage:COUNt?'.format(self._channel))
         if result:
-            if result[0] == value:
+            if int(result) == value:
                 raise InstrIOError(cleandoc('''ZVA24 did not set correctly the
                     channel {} average count'''.format(self._channel)))
         else:
@@ -690,7 +676,7 @@ class ZVA24Channel(BaseInstrument):
     def average_mode(self):
         """
         """
-        mode = self._pna.ask('SENSe{}:AVERage:MODE?'.format(self._channel))
+        mode = self._pna.query('SENSe{}:AVERage:MODE?'.format(self._channel))
         if mode:
             return mode
         else:
@@ -703,7 +689,7 @@ class ZVA24Channel(BaseInstrument):
         """
         """
         self._pna.write('SENSe{}:AVERage:MODE {}'.format(self._channel, value))
-        result = self._pna.ask('SENSe{}:AVERage:MODE?'.format(self._channel))
+        result = self._pna.query('SENSe{}:AVERage:MODE?'.format(self._channel))
 
         if result.lower() != value.lower()[:len(result)]:
             raise InstrIOError(cleandoc('''ZVA24 did not set correctly the
@@ -714,10 +700,10 @@ class ZVA24Channel(BaseInstrument):
     def electrical_delay(self):
         """electrical delay for the selected trace in ns
         """
-        mode = self._pna.ask_for_values('CORRection:EDELay{}?'.format(
+        mode = self._pna.query('CORRection:EDELay{}?'.format(
                                                     self._channel))
         if mode:
-            return mode[0]*1000000000.0
+            return float(mode)*1000000000.0
         else:
             raise InstrIOError(cleandoc('''ZVA24 did not return the
                     channel {} electrical delay'''.format(self._channel)))
@@ -728,8 +714,7 @@ class ZVA24Channel(BaseInstrument):
         """
         electrical delay for the selected trace in ns
         """
-        self._pna.write('CORRection:EDELay{} {}NS'.format(self._channel,
-                                                          value))
+        self._pna.write('CORRection:EDELay{} {}NS'.format(self._channel, value))
 
 
 class ZVA24(VisaInstrument):
@@ -771,7 +756,7 @@ class ZVA24(VisaInstrument):
     def clear_traces_from_window(self, window_num):
         """
         """
-        traces_list = self.ask('DISPlay:WINDow{}:TRACe:CATalog?'.
+        traces_list = self.query('DISPlay:WINDow{}:TRACe:CATalog?'.
                                format(window_num))[1:-1].split(',')
         traces = [int(traces_list[2*ii])
                   for ii in range(int(len(traces_list)/2))]
@@ -780,7 +765,7 @@ class ZVA24(VisaInstrument):
                 mess = 'DISPlay:WINDow{}:TRACe{}:DELete'.format(window_num,
                                                                 int(trace))
                 self.write(mess)
-            traces_list = self.ask('DISPlay:WINDow{}:TRACe:CATalog?'.
+            traces_list = self.query('DISPlay:WINDow{}:TRACe:CATalog?'.
                                    format(window_num))[1:-1].split(',')
             traces = [int(traces_list[2*ii])
                       for ii in range(int(len(traces_list)/2))]
@@ -803,7 +788,7 @@ class ZVA24(VisaInstrument):
     def check_operation_completion(self):
         """
         """
-        return bool(int(self.ask('*OPC?')))
+        return bool(int(self.query('*OPC?')))
 
     @secure_communication()
     def set_all_chanel_to_hold(self):
@@ -814,7 +799,7 @@ class ZVA24(VisaInstrument):
             # TODO: find correct syntax to ask for sweep control state
 # =============================================================================
 #         for channel in self.defined_channels:
-#             result = self.ask('SENSe{}:SWEep:MODE?'.format(channel))
+#             result = self.query('SENSe{}:SWEep:MODE?'.format(channel))
 #             if result != 'HOLD':
 #                 raise InstrIOError(cleandoc('''ZVA24 did not set correctly
 #                     the channel {} sweep mode while setting all
@@ -835,7 +820,7 @@ class ZVA24(VisaInstrument):
     def defined_channels(self):
         """
         """
-        channels = self.ask('CONFigure:CHANnel:CATalog?')
+        channels = self.query('CONFigure:CHANnel:CATalog?')
         if channels:
             channels_number_list = channels[1:-2].split(',')
             n_channels = int(len(channels_number_list)/2)
@@ -849,7 +834,7 @@ class ZVA24(VisaInstrument):
     @instrument_property
     @secure_communication()
     def get_all_trace_names(self):
-        tracelist_raw = self.ask('CONFigure:TRACe:CATalog?')
+        tracelist_raw = self.query('CONFigure:TRACe:CATalog?')
         tracelist = tracelist_raw[1:-1].split(',')
         tracelist = np.reshape(tracelist, (int(len(tracelist)/2), 2))
         tracelist = tracelist[:, 1]
@@ -860,7 +845,7 @@ class ZVA24(VisaInstrument):
     def windows(self):
         """
         """
-        windows = self.ask('DISPlay:CATalog?')
+        windows = self.query('DISPlay:CATalog?')
         if windows:
             windows_number_list = windows[1:-2].split(',')
             aux = [int(windows_number_list[2*ii])
@@ -877,7 +862,7 @@ class ZVA24(VisaInstrument):
         """
         """
         channel = self.defined_channels[0]
-        scope = self.ask('INITiate'+format(channel)+':SCOPe?')
+        scope = self.query('INITiate'+format(channel)+':SCOPe?')
         if scope:
             if scope == 'SINGle' or scope == 'SING':
                 scope = 'CURRent'
@@ -896,7 +881,7 @@ class ZVA24(VisaInstrument):
             value = 'SINGle'
         channel = self.defined_channels[0]
         self.write('INITiate'+format(channel)+':SCOPe {}'.format(value))
-        result = self.ask('INITiate'+format(channel)+':SCOPe?')
+        result = self.query('INITiate'+format(channel)+':SCOPe?')
 
         if result.lower() != value.lower()[:len(result)]:
             raise InstrIOError(cleandoc('''ZVA24 did not set correctly the
@@ -907,7 +892,7 @@ class ZVA24(VisaInstrument):
     def trigger_source(self):
         """
         """
-        scope = self.ask('TRIGger:SEQuence:SOURce?')
+        scope = self.query('TRIGger:SEQuence:SOURce?')
         if scope:
             return scope
         else:
@@ -923,7 +908,7 @@ class ZVA24(VisaInstrument):
         # INITiate will start the measurement
         value = 'IMM'
         self.write('TRIGger:SEQuence:SOURce {}'.format(value))
-        result = self.ask('TRIGger:SEQuence:SOURce?')
+        result = self.query('TRIGger:SEQuence:SOURce?')
 
         if result.lower() != value.lower()[:len(result)]:
             raise InstrIOError(cleandoc('''ZVA24 did not set correctly the
@@ -934,7 +919,7 @@ class ZVA24(VisaInstrument):
     def data_format(self):
         """
         """
-        data_format = self.ask('FORMAT:DATA?')
+        data_format = self.query('FORMAT:DATA?')
         if data_format:
             return data_format
         else:
@@ -947,7 +932,7 @@ class ZVA24(VisaInstrument):
         """
         """
         self.write('FORMAT:DATA {}'.format(value))
-        result = self.ask('FORMAT:DATA?')
+        result = self.query('FORMAT:DATA?')
 
         if result.lower() != value.lower()[:len(result)]:
             raise InstrIOError(cleandoc('''ZVA24 did not set correctly the
@@ -959,9 +944,9 @@ class ZVA24(VisaInstrument):
         """Output state of the source.
 
         """
-        output = self.ask_for_values(':OUTP?')
-        if output is not None:
-            return bool(output[0])
+        output = self.query(':OUTP?')
+        if output:
+            return bool(int(output))
         else:
             mes = 'ZNB signal generator did not return its output'
             raise InstrIOError(mes)
@@ -976,12 +961,12 @@ class ZVA24(VisaInstrument):
         off = re.compile('off', re.IGNORECASE)
         if on.match(value) or value == 1:
             self.write(':OUTPUT ON')
-            if self.ask(':OUTPUT?') != '1':
+            if self.query(':OUTPUT?') != '1':
                 raise InstrIOError(cleandoc('''Instrument did not set correctly
                                         the output'''))
         elif off.match(value) or value == 0:
             self.write(':OUTPUT OFF')
-            if self.ask(':OUTPUT?') != '0':
+            if self.query(':OUTPUT?') != '0':
                 raise InstrIOError(cleandoc('''Instrument did not set correctly
                                         the output'''))
         else:

--- a/exopy_hqc_legacy/instruments/drivers/visa/tabor_awg.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/tabor_awg.py
@@ -63,8 +63,7 @@ class TaborAWGChannel(BaseInstrument):
         """
         with self.secure():
             self._AWG.write('INST {}'.format(self._channel))
-            output = self._AWG.ask('OUTP?'
-                                             )
+            output = self._AWG.query('OUTP?')
             if output == 'ON':
                 return 'ON'
             elif output == 'OFF':
@@ -88,16 +87,14 @@ class TaborAWGChannel(BaseInstrument):
                 self._AWG.write('INST {}'.format(self._channel))
                 self._AWG.write('SOUR:FUNC:MODE USER')
                 self._AWG.write('OUTP ON')
-                if self._AWG.ask('OUTP?'
-                                            ) != 'ON':
+                if self._AWG.query('OUTP?') != 'ON':
                     raise InstrIOError(cleandoc('''Instrument did not set
                                                 correctly the output'''))
             elif off.match(value) or value == 0:
                 self._AWG.write('INST {}'.format(self._channel))
                 self._AWG.write('SOUR:FUNC:MODE USER')
                 self._AWG.write('OUTP OFF')
-                if self._AWG.ask('OUTP?'
-                                            ) != 'OFF':
+                if self._AWG.query('OUTP?') != 'OFF':
                     raise InstrIOError(cleandoc('''Instrument did not set
                                                 correctly the output'''))
             else:
@@ -158,7 +155,7 @@ class TaborAWG(VisaInstrument):
     def oscillator_reference_external(self):
         """oscillator reference external getter method
         """
-        ore = self.ask("SOUR:ROSC:SOUR?")
+        ore = self.query("SOUR:ROSC:SOUR?")
         if ore == 'EXT':
             return 'True'
         elif ore == 'INT':
@@ -173,13 +170,13 @@ class TaborAWG(VisaInstrument):
         """
         if value in ('EXT', 1, 'True'):
             self.write('SOUR:ROSC:SOUR EXT')
-            if self.ask('SOUR:ROSC:SOUR?') != 'EXT':
+            if self.query('SOUR:ROSC:SOUR?') != 'EXT':
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the oscillator
                                             reference'''))
         elif value in ('INT', 0, 'False'):
             self.write('SOUR:ROSC:SOUR INT')
-            if self.ask('SOUR:ROSC:SOUR?') != 'INT':
+            if self.query('SOUR:ROSC:SOUR?') != 'INT':
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the oscillator
                                             reference'''))
@@ -193,10 +190,10 @@ class TaborAWG(VisaInstrument):
     @secure_communication()
     def clock_source(self):
         """clock source getter method
-        """       
-        
-        cle = self.ask("FREQ:RAST:SOUR?")
-        if cle is not None:
+        """
+
+        cle = self.query("FREQ:RAST:SOUR?")
+        if cle:
             return cle
         else:
             raise InstrIOError
@@ -208,12 +205,12 @@ class TaborAWG(VisaInstrument):
         """
         if value in ('EXT', 1, 'True'):
             self.write(':FREQ:RAST:SOUR EXT')
-            if self.ask(':FREQ:RAST:SOUR?') != 'EXT':
+            if self.query(':FREQ:RAST:SOUR?') != 'EXT':
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the clock source'''))
         elif value in ('INT', 0, 'False'):
             self.write(':FREQ:RAST:SOUR INT')
-            if self.ask(':FREQ:RAST:SOUR?') != 'INT':
+            if self.query(':FREQ:RAST:SOUR?') != 'INT':
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the clock source'''))
         else:
@@ -227,9 +224,9 @@ class TaborAWG(VisaInstrument):
     def sampling_frequency(self):
         """sampling frequency getter method
         """
-        sampl_freq = self.ask_for_values("FREQ:RAST?")[0]
-        if sampl_freq is not None:
-            return sampl_freq
+        sampl_freq = self.query("FREQ:RAST?")
+        if sampl_freq:
+            return float(sampl_freq)
         else:
             raise InstrIOError
 
@@ -239,7 +236,7 @@ class TaborAWG(VisaInstrument):
         """sampling frequency setter method
         """
         self.write("FREQ:RAST {}".format(value))
-        result = self.ask_for_values("FREQ:RAST?")[0]
+        result = float(self.query("FREQ:RAST?"))
         if abs(result - value) > 10**-12:
             raise InstrIOError(cleandoc('''Instrument did not set correctly
                                         the sampling frequency'''))
@@ -263,8 +260,8 @@ class TaborAWG(VisaInstrument):
     def run_mode(self):
         """Run mode getter method
         """
-        run_cont = self.ask("INIT:CONT?")
-        run_gat=self.ask("INIT:GATE?")
+        run_cont = self.query("INIT:CONT?")
+        run_gat=self.query("INIT:GATE?")
         if run_cont is not None:
             if run_cont == 'ON':
                 return 'Continuous'
@@ -272,7 +269,6 @@ class TaborAWG(VisaInstrument):
                 return 'Gated'
             else:
                 return 'Triggered'
-            
         else:
             raise InstrIOError
 
@@ -283,25 +279,25 @@ class TaborAWG(VisaInstrument):
         """
         if value in ('CONT', 'CONTINUOUS', 'continuous'):
             self.write('INIT:CONT ON')
-            if self.ask('INIT:CONT?') != 'ON':
+            if self.query('INIT:CONT?') != 'ON':
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the run mode'''))
         elif value in ('TRIG', 'TRIGGERED', 'triggered'):
             self.write('INIT:CONT OFF')
             self.write('INIT:GATE OFF')
-            if self.ask('INIT:CONT?') != 'OFF':
+            if self.query('INIT:CONT?') != 'OFF':
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the run mode'''))
-            elif self.ask('INIT:GATE?') != 'OFF':
+            elif self.query('INIT:GATE?') != 'OFF':
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the run mode'''))
         elif value in ('GAT', 'GATED', 'gated'):
             self.write('INIT:CONT OFF')
             self.write('INIT:GATE ON')
-            if self.ask('INIT:CONT?') != 'OFF':
+            if self.query('INIT:CONT?') != 'OFF':
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the run mode'''))
-            elif self.ask('INIT:GATE?') != 'ON':
+            elif self.query('INIT:GATE?') != 'ON':
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the run mode'''))
         else:

--- a/exopy_hqc_legacy/instruments/drivers/visa/tektro_awg.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/tektro_awg.py
@@ -64,7 +64,7 @@ class AWGChannel(BaseInstrument):
         """
         self._AWG.clear_output_buffer()
         try:
-            current_length = int(self._AWG.ask("SEQuence:LENGth?"))
+            current_length = int(self._AWG.query("SEQuence:LENGth?"))
         except Exception:
             log = logging.getLogger(__name__)
             msg = 'Could not read current_length, assuming 0'
@@ -72,11 +72,11 @@ class AWGChannel(BaseInstrument):
             current_length = 0
         if position > current_length:
             self._AWG.write("SEQuence:LENGth {}".format(position))
-        self._AWG.ask('*ESR?')
+        self._AWG.query('*ESR?')
         msg = 'SEQuence:ELEMent{}:WAVeform{} "{}"'
         self._AWG.write(msg.format(position, self._channel, name))
         # ESR bit 5 signal a command error
-        assert int(self._AWG.ask('*ESR?')) & 2**5 == 0, 'Command failed'
+        assert int(self._AWG.query('*ESR?')) & 2**5 == 0, 'Command failed'
 
     @contextmanager
     def secure(self):
@@ -101,11 +101,10 @@ class AWGChannel(BaseInstrument):
 
         """
         with self.secure():
-            output = self._AWG.ask_for_values('OUTP{}:STAT?'
-                                              .format(self._channel))[0]
-            if output == 1:
+            output = self._AWG.query('OUTP{}:STAT?'.format(self._channel))
+            if output == '1':
                 return 'ON'
-            elif output == 0:
+            elif output == '0':
                 return 'OFF'
             else:
                 mes = cleandoc('AWG channel {} did not return its output'
@@ -124,14 +123,12 @@ class AWGChannel(BaseInstrument):
             if on.match(value) or value == 1:
 
                 self._AWG.write('OUTP{}:STAT ON'.format(self._channel))
-                if self._AWG.ask_for_values('OUTP{}:STAT?'
-                                            .format(self._channel))[0] != 1:
+                if self._AWG.query('OUTP{}:STAT?'.format(self._channel)) != '1':
                     raise InstrIOError(cleandoc('''Instrument did not set
                                                 correctly the output'''))
             elif off.match(value) or value == 0:
                 self._AWG.write('OUTP{}:STAT OFF'.format(self._channel))
-                if self._AWG.ask_for_values('OUTP{}:STAT?'
-                                            .format(self._channel))[0] != 0:
+                if self._AWG.query('OUTP{}:STAT?'.format(self._channel)) != '0':
                     raise InstrIOError(cleandoc('''Instrument did not set
                                                 correctly the output'''))
             else:
@@ -146,10 +143,10 @@ class AWGChannel(BaseInstrument):
 
         """
         with self.secure():
-            m1_HV = self._AWG.ask_for_values("SOURce{}:MARK1:VOLTage:HIGH?"
-                                             .format(self._channel))[0]
-            if m1_HV is not None:
-                return m1_HV
+            m1_HV = self._AWG.query("SOURce{}:MARK1:VOLTage:HIGH?"
+                                    .format(self._channel))
+            if m1_HV:
+                return float(m1_HV)
             else:
                 raise InstrIOError
 
@@ -162,8 +159,8 @@ class AWGChannel(BaseInstrument):
         with self.secure():
             self._AWG.write("SOURce{}:MARK1:VOLTage:HIGH {}"
                             .format(self._channel, value))
-            result = self._AWG.ask_for_values("SOURce{}:MARK1:VOLTage:HIGH?"
-                                              .format(self._channel))[0]
+            result = float(self._AWG.query("SOURce{}:MARK1:VOLTage:HIGH?"
+                                           .format(self._channel)))
             if abs(result - value) > 10**-12:
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the marker1 high
@@ -176,10 +173,10 @@ class AWGChannel(BaseInstrument):
 
         """
         with self.secure():
-            m2_HV = self._AWG.ask_for_values("SOURce{}:MARK2:VOLTage:HIGH?"
-                                             .format(self._channel))[0]
-            if m2_HV is not None:
-                return m2_HV
+            m2_HV = float(self._AWG.query("SOURce{}:MARK2:VOLTage:HIGH?"
+                                          .format(self._channel)))
+            if m2_HV:
+                return float(m2_HV)
             else:
                 raise InstrIOError
 
@@ -192,8 +189,8 @@ class AWGChannel(BaseInstrument):
         with self.secure():
             self._AWG.write("SOURce{}:MARK2:VOLTage:HIGH {}"
                             .format(self._channel, value))
-            result = self._AWG.ask_for_values("SOURce{}:MARK2:VOLTage:HIGH?"
-                                              .format(self._channel))[0]
+            result = float(self._AWG.query("SOURce{}:MARK2:VOLTage:HIGH?"
+                                           .format(self._channel)))
             if abs(result - value) > 10**-12:
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the marker2 high
@@ -206,10 +203,10 @@ class AWGChannel(BaseInstrument):
 
         """
         with self.secure():
-            m1_LV = self._AWG.ask_for_values("SOURce{}:MARK1:VOLTage:LOW?"
-                                             .format(self._channel))[0]
-            if m1_LV is not None:
-                return m1_LV
+            m1_LV = self._AWG.query("SOURce{}:MARK1:VOLTage:LOW?"
+                                    .format(self._channel))
+            if m1_LV:
+                return float(m1_LV)
             else:
                 raise InstrIOError
 
@@ -222,8 +219,8 @@ class AWGChannel(BaseInstrument):
         with self.secure():
             self._AWG.write("SOURce{}:MARK1:VOLTage:LOW {}"
                             .format(self._channel, value))
-            result = self._AWG.ask_for_values("SOURce{}:MARK1:VOLTage:LOW?"
-                                              .format(self._channel))[0]
+            result = float(self._AWG.query("SOURce{}:MARK1:VOLTage:LOW?"
+                                           .format(self._channel)))
             if abs(result - value) > 10**-12:
                 raise InstrIOError(cleandoc('''AWG channel {} did not set
                                             correctly the marker1 low
@@ -236,10 +233,10 @@ class AWGChannel(BaseInstrument):
 
         """
         with self.secure():
-            m2_LV = self._AWG.ask_for_values("SOURce{}:MARK2:VOLTage:LOW?"
-                                             .format(self._channel))[0]
-            if m2_LV is not None:
-                return m2_LV
+            m2_LV = self._AWG.query("SOURce{}:MARK2:VOLTage:LOW?"
+                                             .format(self._channel))
+            if m2_LV:
+                return float(m2_LV)
             else:
                 raise InstrIOError
 
@@ -252,8 +249,8 @@ class AWGChannel(BaseInstrument):
         with self.secure():
             self._AWG.write("SOURce{}:MARK2:VOLTage:LOW {}"
                             .format(self._channel, value))
-            result = self._AWG.ask_for_values("SOURce{}:MARK2:VOLTage:LOW?"
-                                              .format(self._channel))[0]
+            result = float(self._AWG.query("SOURce{}:MARK2:VOLTage:LOW?"
+                                           .format(self._channel)))
             if abs(result - value) > 10**-12:
                 raise InstrIOError(cleandoc('''AWG channel {} did not set
                                             correctly the marker2 low
@@ -266,10 +263,9 @@ class AWGChannel(BaseInstrument):
 
         """
         with self.secure():
-            m1_delay = self._AWG.ask_for_values("SOURce{}:MARK1:DEL?"
-                                                .format(self._channel))[0]
-            if m1_delay is not None:
-                return m1_delay
+            m1_delay = self._AWG.query("SOURce{}:MARK1:DEL?".format(self._channel))
+            if m1_delay:
+                return float(m1_delay)
             else:
                 raise InstrIOError
 
@@ -282,8 +278,8 @@ class AWGChannel(BaseInstrument):
         with self.secure():
             self._AWG.write("SOURce{}:MARK1:DEL {}"
                             .format(self._channel, value))
-            result = self._AWG.ask_for_values("SOURce{}:MARK1:DEL?"
-                                              .format(self._channel))[0]
+            result = float(self._AWG.query("SOURce{}:MARK1:DEL?"
+                                           .format(self._channel)))
             if abs(result - value) > 10**-12:
                 raise InstrIOError(cleandoc('''AWG channel {} did not set
                                             correctly the marker1 delay
@@ -296,10 +292,9 @@ class AWGChannel(BaseInstrument):
 
         """
         with self.secure():
-            m2_delay = self._AWG.ask_for_values("SOURce{}:MARK2:DEL?"
-                                                .format(self._channel))[0]
-            if m2_delay is not None:
-                return m2_delay
+            m2_delay = self._AWG.query("SOURce{}:MARK2:DEL?".format(self._channel))
+            if m2_delay:
+                return float(m2_delay)
             else:
                 raise InstrIOError
 
@@ -312,8 +307,8 @@ class AWGChannel(BaseInstrument):
         with self.secure():
             self._AWG.write("SOURce{}:MARK2:DEL {}"
                             .format(self._channel, value))
-            result = self._AWG.ask_for_values("SOURce{}:MARK2:DEL?"
-                                              .format(self._channel))[0]
+            result = float(self._AWG.query("SOURce{}:MARK2:DEL?"
+                                           .format(self._channel)))
             if abs(result - value) > 10**-12:
                 raise InstrIOError(cleandoc('''AWG channel {} did not set
                                             correctly the marker2 delay
@@ -326,10 +321,9 @@ class AWGChannel(BaseInstrument):
 
         """
         with self.secure():
-            dela = self._AWG.ask_for_values("SOURce{}:DEL:ADJ?"
-                                            .format(self._channel))[0]
-            if dela is not None:
-                return dela
+            dela = self._AWG.query("SOURce{}:DEL:ADJ?".format(self._channel))
+            if dela:
+                return float(dela)
             else:
                 raise InstrIOError
 
@@ -342,8 +336,8 @@ class AWGChannel(BaseInstrument):
         with self.secure():
             self._AWG.write("SOURce{}:DEL:ADJ {}"
                             .format(self._channel, value))
-            result = self._AWG.ask_for_values("SOURce{}:DEL:ADJ?"
-                                              .format(self._channel))[0]
+            result = float(self._AWG.query("SOURce{}:DEL:ADJ?"
+                                           .format(self._channel)))
             if abs(result - value) > 10**-12:
                 raise InstrIOError(cleandoc('''AWG channel {} did not set
                                             correctly the delay'''
@@ -357,9 +351,9 @@ class AWGChannel(BaseInstrument):
         """
         with self.secure():
             msg = "SOURce{}:VOLTage:LEVel:IMMediate:OFFSet?"
-            offs = self._AWG.ask_for_values((msg.format(self._channel)))[0]
-            if offs is not None:
-                return offs
+            offs = self._AWG.query((msg.format(self._channel)))
+            if offs:
+                return float(offs)
             else:
                 raise InstrIOError
 
@@ -373,7 +367,7 @@ class AWGChannel(BaseInstrument):
             self._AWG.write("SOURce{}:VOLTage:LEVel:IMMediate:OFFSet {}"
                             .format(self._channel, value))
             cmd = "SOURce{}:VOLTage:LEVel:IMMediate:OFFSet?"
-            result = self._AWG.ask_for_values(cmd.format(self._channel))[0]
+            result = float(self._AWG.query(cmd.format(self._channel)))
             if abs(result - value) > 10**-12:
                 raise InstrIOError(cleandoc('''AWG channel {} did not set
                                             correctly the offset'''
@@ -386,10 +380,9 @@ class AWGChannel(BaseInstrument):
 
         """
         with self.secure():
-            vp = self._AWG.ask_for_values("SOURce{}:VOLTage?"
-                                          .format(self._channel))[0]
-            if vp is not None:
-                return vp
+            vp = self._AWG.query("SOURce{}:VOLTage?".format(self._channel))
+            if vp:
+                return float(vp)
             else:
                 raise InstrIOError
 
@@ -402,8 +395,8 @@ class AWGChannel(BaseInstrument):
         with self.secure():
             self._AWG.write("SOURce{}:VOLTage {}"
                             .format(self._channel, value))
-            result = self._AWG.ask_for_values("SOURce{}:VOLTage?"
-                                              .format(self._channel))[0]
+            result = float(self._AWG.query("SOURce{}:VOLTage?"
+                                           .format(self._channel)))
             if abs(result - value) > 10**-12:
                 raise InstrIOError(cleandoc('''AWG channel {} did not set
                                             correctly the vpp'''
@@ -416,10 +409,9 @@ class AWGChannel(BaseInstrument):
 
         """
         with self.secure():
-            phi = self._AWG.ask_for_values("SOURce{}:PHAS:ADJ?"
-                                           .format(self._channel))[0]
-            if phi is not None:
-                return phi
+            phi = self._AWG.query("SOURce{}:PHAS:ADJ?".format(self._channel))
+            if phi:
+                return float(phi)
             else:
                 raise InstrIOError
 
@@ -432,8 +424,8 @@ class AWGChannel(BaseInstrument):
         with self.secure():
             self._AWG.write("SOURce{}:PHAS:ADJ {}"
                             .format(self._channel, value))
-            result = self._AWG.ask_for_values("SOURce{}:PHAS:ADJ?"
-                                              .format(self._channel))[0]
+            result = float(self._AWG.query("SOURce{}:PHAS:ADJ?"
+                                           .format(self._channel)))
             if abs(result - value) > 10**-12:
                 raise InstrIOError(cleandoc('''AWG channel {} did not set
                                             correctly the phase'''
@@ -544,7 +536,7 @@ class AWG(VisaInstrument):
         """Getter for internal trigger period
 
         """
-        return self.ask("TRIGGER:SEQUENCE:TIMER?")
+        return self.query("TRIGGER:SEQUENCE:TIMER?")
 
     @internal_trigger_period.setter
     @secure_communication()
@@ -560,7 +552,7 @@ class AWG(VisaInstrument):
         """Getter for trigger internal or external
 
         """
-        ore = self.ask("TRIGGER:SEQUENCE:SOURCE?")
+        ore = self.query("TRIGGER:SEQUENCE:SOURCE?")
         if ore == 'INT':
             return 'True'
         elif ore == 'EXT':
@@ -597,7 +589,7 @@ class AWG(VisaInstrument):
         """Oscillator reference external getter method
 
         """
-        ore = self.ask("SOUR:ROSC:SOUR?")
+        ore = self.query("SOUR:ROSC:SOUR?")
         if ore == 'EXT':
             return 'True'
         elif ore == 'INT':
@@ -613,13 +605,13 @@ class AWG(VisaInstrument):
         """
         if value in ('EXT', 1, 'True'):
             self.write('SOUR:ROSC:SOUR EXT')
-            if self.ask('SOUR:ROSC:SOUR?') != 'EXT':
+            if self.query('SOUR:ROSC:SOUR?') != 'EXT':
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the oscillator
                                             reference'''))
         elif value in ('INT', 0, 'False'):
             self.write('SOUR:ROSC:SOUR INT')
-            if self.ask('SOUR:ROSC:SOUR?') != 'INT':
+            if self.query('SOUR:ROSC:SOUR?') != 'INT':
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the oscillator
                                             reference'''))
@@ -635,7 +627,7 @@ class AWG(VisaInstrument):
         """Clock source getter method
 
         """
-        cle = self.ask("AWGControl:CLOCk:SOURce?")
+        cle = self.query("AWGControl:CLOCk:SOURce?")
         if cle is not None:
             return cle
         else:
@@ -649,12 +641,12 @@ class AWG(VisaInstrument):
         """
         if value in ('EXT', 1, 'True'):
             self.write('AWGControl:CLOCk:SOURce EXT')
-            if self.ask('AWGControl:CLOCk:SOURce?') != 'EXT':
+            if self.query('AWGControl:CLOCk:SOURce?') != 'EXT':
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the clock source'''))
         elif value in ('INT', 0, 'False'):
             self.write('AWGControl:CLOCk:SOURce INT')
-            if self.ask('AWGControl:CLOCk:SOURce?') != 'INT':
+            if self.query('AWGControl:CLOCk:SOURce?') != 'INT':
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the clock source'''))
         else:
@@ -669,9 +661,9 @@ class AWG(VisaInstrument):
         """Sampling frequency getter method
 
         """
-        sampl_freq = self.ask_for_values("SOUR:FREQ:CW?")[0]
-        if sampl_freq is not None:
-            return sampl_freq
+        sampl_freq = self.query("SOUR:FREQ:CW?")
+        if sampl_freq:
+            return float(sampl_freq)
         else:
             raise InstrIOError
 
@@ -682,7 +674,7 @@ class AWG(VisaInstrument):
 
         """
         self.write("SOUR:FREQ:CW {}".format(value))
-        result = self.ask_for_values("SOUR:FREQ:CW?")[0]
+        result = float(self.query("SOUR:FREQ:CW?"))
         if abs(result - value) > 10**-12:
             raise InstrIOError(cleandoc('''Instrument did not set correctly
                                         the sampling frequency'''))
@@ -694,12 +686,12 @@ class AWG(VisaInstrument):
 
         """
         self.clear_output_buffer()
-        run = self.ask_for_values("AWGC:RST?")[0]
-        if run == 0:
+        run = self.query("AWGC:RST?")
+        if run == '0':
             return '0 : Instrument has stopped'
-        elif run == 1:
+        elif run == '1':
             return '1 : Instrument is waiting for trigger'
-        elif run == 2:
+        elif run == '2':
             return '2 : Intrument is running'
         else:
             raise InstrIOError
@@ -713,12 +705,12 @@ class AWG(VisaInstrument):
         self.clear_output_buffer()
         if value in ('RUN', 1, 'True'):
             self.write('AWGC:RUN:IMM')
-            if self.ask_for_values('AWGC:RST?')[0] not in (1, 2):
+            if int(self.query('AWGC:RST?')) not in (1, 2):
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the run state'''))
         elif value in ('STOP', 0, 'False'):
             self.write('AWGC:STOP:IMM')
-            if self.ask_for_values('AWGC:RST?')[0] != 0:
+            if int(self.query('AWGC:RST?')) != 0:
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the run state'''))
         else:
@@ -733,7 +725,7 @@ class AWG(VisaInstrument):
 
         """
         self.clear_output_buffer()
-        run_mode = self.ask("AWGControl:RMODe?")
+        run_mode = self.query("AWGControl:RMODe?")
         if run_mode is not None:
             return run_mode
         else:

--- a/exopy_hqc_legacy/instruments/drivers/visa/tinybuilt.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/tinybuilt.py
@@ -68,10 +68,10 @@ class TinyBiltChannel(BaseInstrument):
         """
 
         with self.secure():
-            output = self._TB.ask_for_values(self._header + 'OUTP?')[0]
-            if output == 1:
+            output = self._TB.query(self._header + 'OUTP?')
+            if output == '1':
                 return 'ON'
-            elif output == 0:
+            elif output == '0':
                 return 'OFF'
             else:
                 mes = 'TinyBilt did not return its output'
@@ -88,12 +88,12 @@ class TinyBiltChannel(BaseInstrument):
             off = re.compile('off', re.IGNORECASE)
             if value == 1 or on.match(str(value)):
                 self._TB.write(self._header + 'OUTP1')
-                if self._TB.ask_for_values(self._header + 'OUTP?')[0] != 1:
+                if self._TB.query(self._header + 'OUTP?') != '1':
                     raise InstrIOError(cleandoc('''Instrument did not set
                                                 correctly the output'''))
             elif value == 0 or off.match(str(value)):
                 self._TB.write(self._header + 'OUTP0')
-                if self._TB.ask_for_values(self._header + 'OUTP?')[0] != 0:
+                if self._TB.query(self._header + 'OUTP?') != '0':
                     raise InstrIOError(cleandoc('''Instrument did not set
                                                 correctly the output'''))
             else:
@@ -109,9 +109,9 @@ class TinyBiltChannel(BaseInstrument):
         big range = 12V and small range = 1.2V
         """
         with self.secure():
-            voltage = self._TB.ask_for_values(self._header + 'volt:rang?')[0]
-            if voltage is not None:
-                return voltage
+            voltage = self._TB.query(self._header + 'volt:rang?')
+            if voltage:
+                return float(voltage)
             else:
                 raise InstrIOError
 
@@ -123,21 +123,21 @@ class TinyBiltChannel(BaseInstrument):
         TinyBilt need to be turned off to change the voltage range
         """
         with self.secure():
-            outp = self._TB.ask_for_values(self._header + 'OUTP?')[0]
+            outp = self._TB.query(self._header + 'OUTP?')
             if outp == 1:
                 raise InstrIOError(cleandoc('''TinyBilt need to be turned
                                                  off to change the voltage
                                                 range'''))
             if value in ('True', 1):
                 self._TB.write(self._header + 'volt:rang 12')
-                result = self._TB.ask_for_values(self._header + 'volt:rang?')[0]
-                if abs(result - 12) > 10**-12:
+                result = self._TB.query(self._header + 'volt:rang?')
+                if abs(float(result) - 12) > 10**-12:
                     mess = 'Instrument did not set correctly the range voltage'
                     raise InstrIOError(mess)
             elif value in ('False', 0):
                 self._TB.write(self._header + 'volt:rang 1.2')
-                result = self._TB.ask_for_values(self._header + 'volt:rang?')[0]
-                if abs(result - 1.2) > 10**-12:
+                result = self._TB.query(self._header + 'volt:rang?')
+                if abs(float(result) - 1.2) > 10**-12:
                     raise InstrIOError(cleandoc('''Instrument did not set
                                                 correctly the range
                                                 voltage'''))
@@ -152,9 +152,9 @@ class TinyBiltChannel(BaseInstrument):
         """max voltage getter method
         """
         with self.secure():
-            maxV = self._TB.ask_for_values(self._header + 'volt:sat:pos?')[0]
-            if maxV is not None:
-                return maxV
+            maxV = self._TB.query(self._header + 'volt:sat:pos?')
+            if maxV:
+                return float(maxV)
             else:
                 raise InstrIOError
 
@@ -165,8 +165,8 @@ class TinyBiltChannel(BaseInstrument):
         """
         with self.secure():
             self._TB.write(self._header + 'volt:sat:pos {}'.format(value))
-            maxiV = self._TB.ask_for_values(self._header + 'volt:sat:pos?')[0]
-            if abs(maxiV - value) > 10**-12:
+            maxiV = self._TB.query(self._header + 'volt:sat:pos?')
+            if abs(float(maxiV) - value) > 10**-12:
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the maximum
                                             voltage'''))
@@ -177,9 +177,9 @@ class TinyBiltChannel(BaseInstrument):
         """min voltage getter method
         """
         with self.secure():
-            minV = self._TB.ask_for_values(self._header + 'volt:sat:neg?')[0]
-            if minV is not None:
-                return minV
+            minV = self._TB.query(self._header + 'volt:sat:neg?')
+            if minV:
+                return float(minV)
             else:
                 raise InstrIOError
 
@@ -190,8 +190,8 @@ class TinyBiltChannel(BaseInstrument):
         """
         with self.secure():
             self._TB.write(self._header + 'volt:sat:neg {}'.format(value))
-            miniV = self._TB.ask_for_values(self._header + 'volt:sat:neg?')[0]
-            if abs(miniV - value) > 10**-12:
+            miniV = self._TB.query(self._header + 'volt:sat:neg?')
+            if abs(float(miniV) - value) > 10**-12:
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the minimum
                                             voltage'''))
@@ -202,9 +202,9 @@ class TinyBiltChannel(BaseInstrument):
         """output value getter method
         """
         with self.secure():
-            outp_val = self._TB.ask_for_values(self._header + 'Volt?')[0]
-            if outp_val is not None:
-                return outp_val
+            outp_val = self._TB.query(self._header + 'Volt?')
+            if outp_val:
+                return float(outp_val)
             else:
                 raise InstrIOError
 
@@ -217,7 +217,7 @@ class TinyBiltChannel(BaseInstrument):
         with self.secure():
             self._TB.write(self._header + 'Volt {}'.format(value))
             self._TB.write(self._header + 'trig:input:init')
-            result = round(self._TB.ask_for_values(self._header + 'Volt?')[0], 5)
+            result = round(float(self._TB.query(self._header + 'Volt?')), 5)
             if abs(result - value) > 1e-12:
                 raise InstrIOError(cleandoc('''Instrument did not set
                                             correctly the output
@@ -230,8 +230,8 @@ class TinyBiltChannel(BaseInstrument):
             with time of time_step between each step
         """
         with self.secure():
-            present_voltage = round(self._TB.ask_for_values
-                                    (self._header + 'Volt?')[0], 5)
+            present_voltage = round(float(self._TB.query
+                                          (self._header + 'Volt?')), 5)
             while abs(round(present_voltage - volt_destination,
                             5)) >= volt_step:
                 time.sleep(time_step)
@@ -288,7 +288,7 @@ class TinyBilt(VisaInstrument):
         """defined_channels is a list of tuple with format (module_number,
                                                                 channel_number)
         """
-        modules = self.ask('I:L?')
+        modules = self.query('I:L?')
         if modules:
             defined_modules = np.array([s.split(',')
                                             for s in modules.split(';')],

--- a/exopy_hqc_legacy/instruments/drivers/visa/yokogawa.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/yokogawa.py
@@ -56,9 +56,9 @@ class YokogawaGS200(VisaInstrument):
         """Voltage getter method. NB: does not check the current function.
 
         """
-        voltage = self.ask_for_values(":SOURce:LEVel?")[0]
-        if voltage is not None:
-            return voltage
+        voltage = self.query(":SOURce:LEVel?")
+        if voltage:
+            return float(voltage)
         else:
             raise InstrIOError('Instrument did not return the voltage')
 
@@ -79,9 +79,9 @@ class YokogawaGS200(VisaInstrument):
 
         """
         self.write(":SOURce:LEVel {}".format(set_point))
-        value = self.ask_for_values('SOURce:LEVel?')[0]
+        value = self.query('SOURce:LEVel?')
         # to avoid floating point rouding
-        if abs(value - round(set_point, 9)) > 10**-9:
+        if abs(float(value) - round(set_point, 9)) > 10**-9:
             raise InstrIOError('Instrument did not set correctly the voltage')
 
     @instrument_property
@@ -92,7 +92,7 @@ class YokogawaGS200(VisaInstrument):
         NB: does not check the current function.
 
         """
-        v_range = self.ask(":SOURce:RANGe?")
+        v_range = self.query(":SOURce:RANGe?")
         if v_range is not None:
             if v_range == '10E-3':
                 return '10 mV'
@@ -129,7 +129,7 @@ class YokogawaGS200(VisaInstrument):
 
         if visa_range:
             self.write(":SOURce:RANGe {}".format(visa_range))
-            check = self.ask(":SOURce:RANGe?")
+            check = self.query(":SOURce:RANGe?")
             if check != visa_range:
                 raise InstrIOError(cleandoc('''Instrument did not set correctly
                     the range'''))
@@ -142,9 +142,9 @@ class YokogawaGS200(VisaInstrument):
         NB: does not check the current function.
 
         """
-        current = self.ask_for_values(":SOURce:LEVel?")[0]
-        if current is not None:
-            return current
+        current = self.query(":SOURce:LEVel?")
+        if current:
+            return float(current)
         else:
             raise InstrIOError('Instrument did not return the current')
 
@@ -157,9 +157,9 @@ class YokogawaGS200(VisaInstrument):
 
         """
         self.write(":SOURce:LEVel {}".format(set_point))
-        value = self.ask_for_values('SOURce:LEVel?')[0]
+        value = self.query('SOURce:LEVel?')
         # to avoid floating point rouding
-        if abs(value - round(set_point, 9)) > 10**-9:
+        if abs(float(value) - round(set_point, 9)) > 10**-9:
             raise InstrIOError('Instrument did not set correctly the current')
 
     @instrument_property
@@ -170,7 +170,7 @@ class YokogawaGS200(VisaInstrument):
         NB: does not check the current function.
 
         """
-        c_range = self.ask(":SOURce:RANGe?")
+        c_range = self.query(":SOURce:RANGe?")
         if c_range is not None:
             if c_range == '1E-3':
                 return '1 mA'
@@ -203,7 +203,7 @@ class YokogawaGS200(VisaInstrument):
 
         if visa_range:
             self.write(":SOURce:RANGe {}".format(visa_range))
-            check = self.ask(":SOURce:RANGe?")
+            check = self.query(":SOURce:RANGe?")
             if check != visa_range:
                 raise InstrIOError(cleandoc('''Instrument did not set correctly
                     the range'''))
@@ -214,8 +214,8 @@ class YokogawaGS200(VisaInstrument):
         """Function getter method
 
         """
-        value = self.ask('SOURce:FUNCtion?')
-        if value is not None:
+        value = self.query('SOURce:FUNCtion?')
+        if value:
             return value
         else:
             raise InstrIOError('Instrument did not return the function')
@@ -231,13 +231,13 @@ class YokogawaGS200(VisaInstrument):
         if self.voltage == 0 and self.output is False:
             if volt.match(mode):
                 self.write(':SOURce:FUNCtion VOLT')
-                value = self.ask('SOURce:FUNCtion?')
+                value = self.query('SOURce:FUNCtion?')
                 if value != 'VOLT':
                     raise InstrIOError('Instrument did not set correctly the'
                                        'mode')
             elif curr.match(mode):
                 self.write(':SOURce:FUNCtion CURR')
-                value = self.ask('SOURce:FUNCtion?')
+                value = self.query('SOURce:FUNCtion?')
                 if value != 'CURR':
                     raise InstrIOError('Instrument did not set correctly the'
                                        'mode')
@@ -257,9 +257,9 @@ class YokogawaGS200(VisaInstrument):
         """Output getter method
 
         """
-        value = self.ask_for_values(':OUTPUT?')
-        if value is not None:
-            return bool(value[0])
+        value = self.query(':OUTPUT?')
+        if value:
+            return bool(int(value))
         else:
             raise InstrIOError('Instrument did not return the output state')
 
@@ -277,12 +277,12 @@ class YokogawaGS200(VisaInstrument):
         if self.voltage == 0:
             if on.match(value) or value == 1:
                 self.write(':OUTPUT ON')
-                if self.ask(':OUTPUT?') != '1':
+                if self.query(':OUTPUT?') != '1':
                     raise InstrIOError(cleandoc('''Instrument did not set
                                                 correctly the output'''))
             elif off.match(value) or value == 0:
                 self.write(':OUTPUT OFF')
-                if self.ask(':OUTPUT?') != '0':
+                if self.query(':OUTPUT?') != '0':
                     raise InstrIOError(cleandoc('''Instrument did not set
                                                 correctly the output'''))
             else:
@@ -337,7 +337,7 @@ class Yokogawa7651(VisaInstrument):
         """Voltage getter method.
 
         """
-        data = self.ask("OD")
+        data = self.query("OD")
         voltage = float(data[4::])
         if voltage is not None:
             return voltage
@@ -362,7 +362,7 @@ class Yokogawa7651(VisaInstrument):
 
         """
         self.write("S{:+E}E".format(set_point))
-        data = self.ask("OD")
+        data = self.query("OD")
         value = float(data[4::])
         # to avoid floating point rouding
         if abs(value - round(set_point, 9)) > 10**-9:
@@ -374,7 +374,7 @@ class Yokogawa7651(VisaInstrument):
         """Function getter method.
 
         """
-        data = self.ask('OD')
+        data = self.query('OD')
         if data[3] == 'V':
             return 'VOLT'
         elif data[3] == 'A':
@@ -399,12 +399,12 @@ class Yokogawa7651(VisaInstrument):
             self.read()
             self.read()
             self.write('F1{}E'.format(current_range))
-            value = self.ask('OD')
+            value = self.query('OD')
             if value[3] != 'V':
                 raise InstrIOError('Instrument did not set correctly the mode')
         elif curr.match(mode):
             self.write('F5E')
-            value = self.ask('OD')
+            value = self.query('OD')
             if value[3] != 'A':
                 raise InstrIOError('Instrument did not set correctly the mode')
         else:
@@ -418,7 +418,7 @@ class Yokogawa7651(VisaInstrument):
         """Output getter method.
 
         """
-        mess = self.ask('OC')[5::]
+        mess = self.query('OC')[5::]
         value = ('{0:08b}'.format(int(mess)))[3]
         if value == '0':
             return 'OFF'
@@ -437,13 +437,13 @@ class Yokogawa7651(VisaInstrument):
         off = re.compile('off', re.IGNORECASE)
         if on.match(value) or value == 1:
             self.write('O1E')
-            mess = self.ask('OC')[5::]  # Instr return STS1=m we want m
+            mess = self.query('OC')[5::]  # Instr return STS1=m we want m
             if ('{0:08b}'.format(int(mess)))[3] != '1':
                 raise InstrIOError(cleandoc('''Instrument did not set correctly
                                             the output'''))
         elif off.match(value) or value == 0:
             self.write('O0E')
-            mess = self.ask('OC')[5::]  # Instr return STS1=m we want m
+            mess = self.query('OC')[5::]  # Instr return STS1=m we want m
             if('{0:08b}'.format(int(mess)))[3] != '0':
                 raise InstrIOError(cleandoc('''Instrument did not set correctly
                                             the output'''))

--- a/exopy_hqc_legacy/instruments/drivers/visa_tools.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa_tools.py
@@ -71,8 +71,9 @@ class VisaInstrument(BaseInstrument):
     write(mess)
     read()
     read_values()
-    ask(mess)
-    ask_for_values()
+    query()
+    query_ascii_values()
+    query_binary_values()
     clear()
     trigger()
     read_raw()
@@ -152,27 +153,6 @@ class VisaInstrument(BaseInstrument):
         stored in the attribute `_driver`
         """
         return self._driver.read_values(format=0)
-
-    def ask(self, message):
-        """Send the specified message to the instrument and read its answer.
-
-        Simple alias for query
-        """
-        return self._driver.query(message)
-
-    def ask_for_values(self, message, format=2):
-        """Send the specified message to the instrument and convert its answer
-        to values.
-
-        DEPRECATED
-
-        By default assume the values are returned as ascii.
-
-        Simply call the `ask_for_values` method of the `Instrument` object
-        stored in the attribute `_driver`
-
-        """
-        return self._driver.ask_for_values(message, format)
 
     def read_ascii_values(self, converter='f', separator=','):
         """Read one line of the instrument's buffer and convert to values.

--- a/exopy_hqc_legacy/instruments/drivers/visa_tools.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa_tools.py
@@ -156,14 +156,15 @@ class VisaInstrument(BaseInstrument):
     def ask(self, message):
         """Send the specified message to the instrument and read its answer.
 
-        Simply call the `ask` method of the `Instrument` object stored in
-        the attribute `_driver`
+        Simple alias for query
         """
         return self._driver.query(message)
 
     def ask_for_values(self, message, format=2):
         """Send the specified message to the instrument and convert its answer
         to values.
+
+        DEPRECATED
 
         By default assume the values are returned as ascii.
 
@@ -172,6 +173,58 @@ class VisaInstrument(BaseInstrument):
 
         """
         return self._driver.ask_for_values(message, format)
+
+    def read_ascii_values(self, converter='f', separator=','):
+        """Read one line of the instrument's buffer and convert to values.
+
+        DEPRECATED
+
+        Simply call the `read_ascii_values` method of the `Instrument` object
+        stored in the attribute `_driver`
+        """
+        return self._driver.read_ascii_values(converter, separator)
+
+    def read_binary_values(self, datatype='f', is_big_endian=False):
+        """Read one line of the instrument's buffer and convert to values.
+
+        DEPRECATED
+
+        Simply call the `read_binary_values` method of the `Instrument` object
+        stored in the attribute `_driver`
+        """
+        return self._driver.read_binary_values(datatype, is_big_endian)
+
+    def query(self, message):
+        """Send the specified message to the instrument and read its answer.
+
+        Simply call the `query` method of the `Instrument` object stored in
+        the attribute `_driver`
+        """
+        return self._driver.query(message)
+
+    def query_ascii_values(self, message, converter='f', separator=','):
+        """Send the specified message to the instrument and convert its answer
+        to values.
+
+        By default assume the values are returned as ascii.
+
+        Simply call the `query_ascii_values` method of the `Instrument` object
+        stored in the attribute `_driver`
+
+        """
+        return self._driver.query_ascii_values(message, converter, separator)
+
+    def query_binary_values(self, message, datatype='f', is_big_endian=False):
+        """Send the specified message to the instrument and convert its answer
+        to values.
+
+        By default assume the values are returned as ascii.
+
+        Simply call the `query_binary_values` method of the `Instrument` object
+        stored in the attribute `_driver`
+
+        """
+        return self._driver.query_binary_values(message, datatype, is_big_endian)
 
     def clear(self):
         """Resets the device (highly bus dependent).


### PR DESCRIPTION
`ask_for_values` has been deprecated by the pyvisa library so this patch updates all uses of `ask` to `query`.

Currently tested:
  - Anapico
  - Anritsu
  - TinyBilt
  - R&S SMB100A
  - Agilent PSG
  - PNA
  - WindfreakTech SynthHD