### PR TITLE
Fix C4G error

### DIFF
--- a/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_g4.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_g4.py
@@ -76,6 +76,16 @@ class C4G(CS4):
         # can't reuse CS4 class because a semi-colon is needed
         self.write('ULIM {};'.format(target * 10))
 
+    @instrument_property
+    @secure_communication()
+    def field_sweep_rate(self):
+        """Rate at which to ramp the field (T/min).
+
+        """
+        # converted from A/s to T/min
+        rate = float(self.ask('RATE? 0'))
+        return rate * (60 * self.field_current_ratio)
+
     @field_sweep_rate.setter
     @secure_communication()
     def field_sweep_rate(self, rate):

--- a/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_g4.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/cryomagnetics_g4.py
@@ -83,7 +83,7 @@ class C4G(CS4):
 
         """
         # converted from A/s to T/min
-        rate = float(self.ask('RATE? 0'))
+        rate = float(self.query('RATE? 0'))
         return rate * (60 * self.field_current_ratio)
 
     @field_sweep_rate.setter


### PR DESCRIPTION
I don't fully understand the interaction between @instrument_property
and inheritance but copying the getter from the parent class seemed to
fix the problem.

This patch fixes the last driver error present when launching exopy on my system.

The call to `ask` will need to be changed into `query` once #71 is merged.