### PR TITLE
Fix the annoying 420 error

### DIFF
--- a/exopy_hqc_legacy/instruments/drivers/visa/agilent_pna.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/agilent_pna.py
@@ -162,7 +162,6 @@ class AgilentPNAChannel(BaseInstrument):
         self._pna.trigger_source = 'Immediate'
         self.sweep_mode = 'Hold'
         self._pna.clear_averaging()
-        self._pna.timeout = 10
 
         if aver_count:
             self.average_count = aver_count
@@ -177,11 +176,9 @@ class AgilentPNAChannel(BaseInstrument):
                     done = self._pna.ask_for_values('*OPC?')[0]
                     break
                 except Exception:
-                    self._pna.timeout = self._pna.timeout*2
-                    logger = logging.getLogger(__name__)
-                    msg = cleandoc('''PNA timeout increased to {} s
-                        This will make the PNA diplay 420 error w/o issue''')
-                    logger.info(msg.format(self._pna.timeout))
+                    # Getting an exception here simply means that the
+                    # PNA isn't done averaging
+                    pass
 
             if done != 1:
                 raise InstrError(cleandoc('''Agilent PNA did could  not perform
@@ -738,6 +735,7 @@ class AgilentPNA(VisaInstrument):
         super(AgilentPNA, self).open_connection(**para)
         self.write_termination = '\n'
         self.read_termination = '\n'
+        self.timeout = 10000 # 10s should be plenty
 
     def get_channel(self, num):
         """

--- a/exopy_hqc_legacy/instruments/drivers/visa/agilent_pna.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/agilent_pna.py
@@ -20,6 +20,8 @@ except ImportError:
     single = 1
     double = 3
 
+from visa import VisaIOError, constants
+
 from ..driver_tools import (BaseInstrument, InstrIOError, InstrError,
                             secure_communication, instrument_property)
 from ..visa_tools import VisaInstrument
@@ -175,10 +177,12 @@ class AgilentPNAChannel(BaseInstrument):
                 try:
                     done = self._pna.ask_for_values('*OPC?')[0]
                     break
-                except Exception:
-                    # Getting an exception here simply means that the
+                except VisaIOError as e:
+                    # Getting an timeout here simply means that the
                     # PNA isn't done averaging
-                    pass
+                    if e.error_code == constants.StatusCode.error_timeout:
+                        continue
+                    raise
 
             if done != 1:
                 raise InstrError(cleandoc('''Agilent PNA did could  not perform


### PR DESCRIPTION
This bug came from a lack of understanding of the timeout. The timeout
(which is in ms and not in s as previously assumed) simply sets the
polling rate of the driver when asking for completion. The interval
started at 10ms which was so small, it was showing errors on the
screen. There is no downside to setting a high timeout since the PNA
will answer as soon as it is done averaging.