### PR TITLE
Add multi-channel anapico driver

### DIFF
--- a/exopy_hqc_legacy/instruments/drivers/visa/anapico.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/anapico.py
@@ -200,3 +200,52 @@ class Anapico(VisaInstrument):
             mess = fill(cleandoc('''The invalid value {} was sent to
                         switch_on_off method''').format(value), 80)
             raise VisaTypeError(mess)
+
+
+class AnapicoMulti(Anapico):
+    """
+    Generic driver for multi-channel Anapico Signal Generators,
+    using the VISA library.
+
+    Parameters
+    ----------
+    see the `VisaInstrument` parameters
+
+    Attributes
+    ----------
+    channel: int
+        Channel currently selected
+    frequency_unit : str
+        Frequency unit used by the driver. The default unit is 'GHz'. Other
+        valid units are : 'MHz', 'KHz', 'Hz'
+    frequency : float, instrument_property
+        Fixed frequency of the output signal.
+    power : float, instrument_property
+        Fixed power of the output signal.
+    output : bool, instrument_property
+        State of the output 'ON'(True)/'OFF'(False).
+    """
+
+    @instrument_property
+    @secure_communication()
+    def channel(self):
+        """Currently selected channel
+
+        """
+        channel = self.query('SOURce:SEL?')
+        if channel:
+            return int(channel)
+        else:
+            raise InstrIOError
+
+    @channel.setter
+    @secure_communication()
+    def channel(self, channel):
+        """Current channel setter method
+
+        """
+        self.write('SOURce:SEL {}'.format(channel))
+        result = int(self.query('SOURce:SEL?'))
+        if result and channel != result:
+            msg = 'Instrument could not select channel {}'
+            raise InstrIOError(msg.format(channel))

--- a/exopy_hqc_legacy/manifest.enaml
+++ b/exopy_hqc_legacy/manifest.enaml
@@ -291,6 +291,12 @@ enamldef HqcLegacyManifest(PluginManifest):
                         model = 'APSING20G'
                         connections = {'VisaTCPIP': {'resource_class': 'INSTR'}
                                        }
+                    Driver:
+                        driver = 'anapico:AnapicoMulti'
+                        model = 'APUASYN20'
+                        connections = {'VisaTCPIP': {'resource_class': 'INSTR'}
+                                       }
+
             Drivers:
                 path = 'dll'
                 starter = 'exopy_hqc_legacy.starter.dll'
@@ -398,6 +404,11 @@ enamldef HqcLegacyManifest(PluginManifest):
                         views = ['views.synthHD_task_views:ISynthHDChannelLabel',
                                  'views.synthHD_task_views:ISynthHDChannelValue']
                         instruments = ['exopy_hqc_legacy.Legacy.SynthHD']
+                    Interface:
+                        interface = 'anapico_tasks:AnapicoSetChannelInterface'
+                        views = ['views.anapico_task_views:IAnapicoChannelLabel',
+                                 'views.anapico_task_views:IAnapicoChannelValue']
+                        instruments = ['exopy_hqc_legacy.Legacy.AnapicoMulti']
                 Task:
                     task = 'rf_tasks:SetRFPowerTask'
                     view = 'views.rf_views:RFPowerView'
@@ -421,6 +432,11 @@ enamldef HqcLegacyManifest(PluginManifest):
                         views = ['views.synthHD_task_views:ISynthHDChannelLabel',
                                  'views.synthHD_task_views:ISynthHDChannelValue']
                         instruments = ['exopy_hqc_legacy.Legacy.SynthHD']
+                    Interface:
+                        interface = 'anapico_tasks:AnapicoSetChannelInterface'
+                        views = ['views.anapico_task_views:IAnapicoChannelLabel',
+                                 'views.anapico_task_views:IAnapicoChannelValue']
+                        instruments = ['exopy_hqc_legacy.Legacy.AnapicoMulti']                        
                 Task:
                     task = 'rf_tasks:SetRFOnOffTask'
                     view = 'views.rf_views:RFSetOnOffView'
@@ -437,11 +453,21 @@ enamldef HqcLegacyManifest(PluginManifest):
                         views = ['views.synthHD_task_views:ISynthHDChannelLabel',
                                  'views.synthHD_task_views:ISynthHDChannelValue']
                         instruments = ['exopy_hqc_legacy.Legacy.SynthHD']
+                    Interface:
+                        interface = 'anapico_tasks:AnapicoSetChannelInterface'
+                        views = ['views.anapico_task_views:IAnapicoChannelLabel',
+                                 'views.anapico_task_views:IAnapicoChannelValue']
+                        instruments = ['exopy_hqc_legacy.Legacy.AnapicoMulti']                        
                 Task:
                     task = 'rf_tasks:SetPulseModulationTask'
                     view = 'views.rf_views:PulseModulationView'
                     instruments = ['exopy_hqc_legacy.Legacy.RohdeSchwarzSMB100A',
                                    'exopy_hqc_legacy.Legacy.Anapico']
+                    Interface:
+                        interface = 'anapico_tasks:AnapicoSetChannelInterface'
+                        views = ['views.anapico_task_views:IAnapicoChannelLabel',
+                                 'views.anapico_task_views:IAnapicoChannelValue']
+                        instruments = ['exopy_hqc_legacy.Legacy.AnapicoMulti']                                   
                 Task:
                     task = 'pna_tasks:PNASinglePointMeasureTask'
                     view = 'views.pna_task_views:PNASinglePointView'

--- a/exopy_hqc_legacy/tasks/tasks/instr/anapico_tasks.py
+++ b/exopy_hqc_legacy/tasks/tasks/instr/anapico_tasks.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2015-2020 by ExopyHqcLegacy Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Interface allowing to use RF tasks with Anapico multi-channel generator.
+
+"""
+from atom.api import Int
+
+from exopy.tasks.api import TaskInterface
+
+
+class AnapicoSetChannelInterface(TaskInterface):
+    """Set the central frequency to be used for the specified channel.
+
+    """
+    #: Id of the channel whose central frequency should be set.
+    channel = Int(1).tag(pref=True)
+
+    def perform(self, frequency=None):
+        """Set the central frequency of the specified channel.
+
+        """
+        task = self.task
+        channel = self.channel
+        task.driver.channel = channel
+        task.i_perform()

--- a/exopy_hqc_legacy/tasks/tasks/instr/views/anapico_task_views.enaml
+++ b/exopy_hqc_legacy/tasks/tasks/instr/views/anapico_task_views.enaml
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2015-2020 by ExopyHqcLegacy Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Views for the Anapico multi=channel RF source interfaces.
+
+"""
+from enaml.widgets.api import Label
+from enaml.stdlib.fields import IntField
+
+enamldef IAnapicoChannelLabel(Label):
+    """Label for the channel selection.
+
+    """
+    attr interface
+    attr root
+    attr index = 2
+    text = 'Channel'
+
+
+enamldef IAnapicoChannelValue(IntField):
+    """Value for the channel selection.
+
+    """
+    attr interface
+    attr root
+    hug_width = 'strong'
+    value := interface.channel
+


### PR DESCRIPTION
This patch adds a driver for multi-channel Anapico RF sources (APUASYN family of sources). The driver is just 2 additional method on top of the existing Anapico driver and I've added interfaces to all RF related tasks to add the add the channel field. The code is inspired by the already working SynthHD driver.

I've already tested this code on the real hardware. I think we are the only Exopy users that have this source but since it's such a small amount of code on top of the existing Anapico driver, I thought it would be better to share on `hqc_legacy` rather than bury it in our own `qcircuits` plugin.