### PR TITLE
[saveHDF5] Fix bug

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ ExopyHqcLegacy Changelog
 
 - fix passing average value when retrying data retrieval on AQD14 driver
 - remove conversion from HQCMeas
+- Fix bug in saveHDF5Task when saving complex record arrays
 
 0.1.0 - 15/02/2018
 ------------------

--- a/exopy_hqc_legacy/tasks/tasks/util/save_tasks.py
+++ b/exopy_hqc_legacy/tasks/tasks/util/save_tasks.py
@@ -578,8 +578,8 @@ class SaveFileHDF5Task(SimpleTask):
                     if names:
                         for m in names:
                             f.create_dataset(label + '_' + m,
-                                             (calls_estimation,) + value.shape,
-                                             (None, ) + value.shape,
+                                             (calls_estimation,) + value[m].shape,
+                                             (None, ) + value[m].shape,
                                              self.datatype,
                                              self.compression)
                     else:


### PR DESCRIPTION
This a simple bug fix for a bug that occurs when trying to save complicated record arrays in HDF5 format.

Written-by: Antoine Essig