### PR TITLE
Fix rohde_and_schwarz_vna (Exopy/exopy_hqc_legacy@9fa16bd)

### DIFF
--- a/exopy_hqc_legacy/instruments/drivers/visa/rohde_and_schwarz_vna.py
+++ b/exopy_hqc_legacy/instruments/drivers/visa/rohde_and_schwarz_vna.py
@@ -95,8 +95,8 @@ class ZNB20Channel(BaseInstrument):
         else:
             data = self._pna.query_ascii_values(data_request)
 
-        if data:
-            return np.array(data)
+        if data.size:
+            return data
         else:
             raise InstrIOError(cleandoc('''ZNB20 did not return the
                 channel {} formatted data for meas {}'''.format(
@@ -136,9 +136,8 @@ class ZNB20Channel(BaseInstrument):
         if not meas_name:
             meas_name = self.selected_measure
 
-        if data:
-            aux = np.array(data)
-            return aux[::2] + 1j*aux[1::2]
+        if data.size:
+            return data[::2] + 1j*data[1::2]
         else:
             raise InstrIOError(cleandoc('''ZNB20 did not return the
                 channel {} formatted data for meas {}'''.format(


### PR DESCRIPTION
Exopy/exopy_hqc_legacy@9fa16bd enforced `np.ndarray` outputs by default in `query_binary_values` and `query_ascii_values`, while `read_raw_data` and `read_formatted_data` in `rohde_and_schwarz_vna.py` still expect a `list` instead of an `np.ndarray`. This is fixed by this PR.

See also: Qcircuits/ecpy_qcircuits/pull/18